### PR TITLE
解像度の変更が入っている H.264 の WebM を合成しようとすると落ちるのを修正

### DIFF
--- a/src/hisui.cpp
+++ b/src/hisui.cpp
@@ -94,5 +94,9 @@ int main(int argc, char** argv) {
   }
   delete muxer;
 
+  if (!config.openh264.empty()) {
+    hisui::video::OpenH264Handler::close();
+  }
+
   return 0;
 }

--- a/src/video/openh264_decoder.cpp
+++ b/src/video/openh264_decoder.cpp
@@ -89,7 +89,7 @@ void OpenH264Decoder::updateImageByTimestamp(const std::uint64_t timestamp) {
     m_current_buffer_info = m_next_buffer_info;
     m_current_timestamp = m_next_timestamp;
     if (m_webm->readFrame()) {
-      SBufferInfo buffer_info;
+      ::SBufferInfo buffer_info;
       const auto ret = m_decoder->DecodeFrameNoDelay(
           m_webm->getBuffer(), static_cast<int>(m_webm->getBufferSize()),
           m_tmp_yuv, &buffer_info);

--- a/src/video/openh264_decoder.cpp
+++ b/src/video/openh264_decoder.cpp
@@ -89,7 +89,7 @@ void OpenH264Decoder::updateImageByTimestamp(const std::uint64_t timestamp) {
   }
 
   do {
-    if (m_current_yuv_image) {
+    if (m_current_yuv_image && m_current_yuv_image != m_next_yuv_image) {
       delete m_current_yuv_image;
     }
     m_current_yuv_image = m_next_yuv_image;

--- a/src/video/openh264_decoder.cpp
+++ b/src/video/openh264_decoder.cpp
@@ -7,6 +7,7 @@
 #include <spdlog/spdlog.h>
 
 #include <limits>
+#include <memory>
 #include <stdexcept>
 
 #include "video/openh264.hpp"
@@ -39,8 +40,10 @@ OpenH264Decoder::OpenH264Decoder(hisui::webm::input::VideoContext* t_webm)
                     decoder_initialize_ret));
   }
 
-  m_current_yuv_image = create_black_yuv_image(m_width, m_height);
-  m_next_yuv_image = create_black_yuv_image(m_width, m_height);
+  m_current_yuv_image =
+      std::shared_ptr<YUVImage>(create_black_yuv_image(m_width, m_height));
+  m_next_yuv_image =
+      std::shared_ptr<YUVImage>(create_black_yuv_image(m_width, m_height));
 
   m_tmp_yuv[0] = nullptr;
   m_tmp_yuv[1] = nullptr;
@@ -48,12 +51,6 @@ OpenH264Decoder::OpenH264Decoder(hisui::webm::input::VideoContext* t_webm)
 }
 
 OpenH264Decoder::~OpenH264Decoder() {
-  if (m_next_yuv_image && m_next_yuv_image != m_current_yuv_image) {
-    delete m_next_yuv_image;
-  }
-  if (m_current_yuv_image) {
-    delete m_current_yuv_image;
-  }
   if (m_decoder) {
     m_decoder->Uninitialize();
     OpenH264Handler::getInstance().destroyDecoder(m_decoder);
@@ -71,7 +68,7 @@ const YUVImage* OpenH264Decoder::getImage(const std::uint64_t timestamp) {
     return m_black_yuv_image;
   }
   updateImage(timestamp);
-  return m_current_yuv_image;
+  return m_current_yuv_image.get();
 }
 
 void OpenH264Decoder::updateImage(const std::uint64_t timestamp) {
@@ -89,9 +86,6 @@ void OpenH264Decoder::updateImageByTimestamp(const std::uint64_t timestamp) {
   }
 
   do {
-    if (m_current_yuv_image && m_current_yuv_image != m_next_yuv_image) {
-      delete m_current_yuv_image;
-    }
     m_current_yuv_image = m_next_yuv_image;
     m_current_timestamp = m_next_timestamp;
     if (m_webm->readFrame()) {
@@ -107,8 +101,9 @@ void OpenH264Decoder::updateImageByTimestamp(const std::uint64_t timestamp) {
       }
       m_next_timestamp = static_cast<std::uint64_t>(m_webm->getTimestamp());
       if (buffer_info.iBufferStatus == 1) {
-        m_next_yuv_image = new YUVImage(m_width, m_height);
-        update_yuv_image_by_openh264_buffer_info(m_next_yuv_image, buffer_info);
+        m_next_yuv_image = std::make_shared<YUVImage>(m_width, m_height);
+        update_yuv_image_by_openh264_buffer_info(m_next_yuv_image.get(),
+                                                 buffer_info);
       }
     } else {
       // m_duration までは m_current_image を出すので webm を読み終えても m_current_image を維持する

--- a/src/video/openh264_decoder.cpp
+++ b/src/video/openh264_decoder.cpp
@@ -4,6 +4,7 @@
 #include <codec/api/svc/codec_app_def.h>
 #include <codec/api/svc/codec_def.h>
 #include <fmt/core.h>
+#include <spdlog/spdlog.h>
 
 #include <limits>
 #include <stdexcept>
@@ -99,6 +100,8 @@ void OpenH264Decoder::updateImageByTimestamp(const std::uint64_t timestamp) {
           m_webm->getBuffer(), static_cast<int>(m_webm->getBufferSize()),
           m_tmp_yuv, &buffer_info);
       if (ret != 0) {
+        spdlog::error(
+            "OpenH264Decoder DecodeFrameNoDelay failed: error_code={}", ret);
         throw std::runtime_error(fmt::format(
             "m_decoder->DecodeFrameNoDelay() failed: error_code={}", ret));
       }

--- a/src/video/openh264_decoder.hpp
+++ b/src/video/openh264_decoder.hpp
@@ -3,6 +3,7 @@
 #include <codec/api/svc/codec_def.h>
 
 #include <cstdint>
+#include <memory>
 
 #include "video/decoder.hpp"
 
@@ -29,8 +30,8 @@ class OpenH264Decoder : public Decoder {
   ::ISVCDecoder* m_decoder = nullptr;
   std::uint64_t m_current_timestamp = 0;
   std::uint64_t m_next_timestamp = 0;
-  YUVImage* m_current_yuv_image = nullptr;
-  YUVImage* m_next_yuv_image = nullptr;
+  std::shared_ptr<YUVImage> m_current_yuv_image = nullptr;
+  std::shared_ptr<YUVImage> m_next_yuv_image = nullptr;
   std::uint8_t* m_tmp_yuv[3];
 
   void updateImage(const std::uint64_t);

--- a/src/video/openh264_decoder.hpp
+++ b/src/video/openh264_decoder.hpp
@@ -30,8 +30,7 @@ class OpenH264Decoder : public Decoder {
   std::uint64_t m_current_timestamp = 0;
   std::uint64_t m_next_timestamp = 0;
   YUVImage* m_current_yuv_image = nullptr;
-  ::SBufferInfo m_current_buffer_info;
-  ::SBufferInfo m_next_buffer_info;
+  YUVImage* m_next_yuv_image = nullptr;
   std::uint8_t* m_tmp_yuv[3];
 
   void updateImage(const std::uint64_t);


### PR DESCRIPTION
hisui では元の動画の fps に関係なく出力の fps を制御するため,
デコーダーにて指定された時間に対応する画像とその次の画像を持っている.

VPX では libvpx の vpx_image_t を用いて保持していて
これにならって OpenH264 の SBufferInfo を用いて保持していたが,
SBufferInfo.pDst は画像毎ではなく使いまわされている.
現在の画像の解像度が次の画像よりも大きい場合,
現在の画像と思ってデコードしようとして buffer overflow してしまっていた.

https://github.com/shiguredo/hisui/blob/develop/third_party/openh264/codec/api/svc/codec_def.h#L197

これを解決するため, SBufferInfo ではなく hisui の YUVImage クラスで
指定された時間に対応する画像とその次の画像を管理するよう変更した.

他に次を行なっている

- コード間での統一のため SBufferInfo を ::SBufferInfo に
- OpenH264 でのデコードのエラー時のログの追加
- OpenH264Handler::close() の呼び出し
    - 実際上の意味はほぼないが valgrind で still reachable となるのを避けるため
