### PR TITLE
std::async で作った Future を get() し例外を伝播させる

### DIFF
--- a/src/muxer/audio_producer.cpp
+++ b/src/muxer/audio_producer.cpp
@@ -1,5 +1,7 @@
 #include "muxer/audio_producer.hpp"
 
+#include <spdlog/spdlog.h>
+
 #include <cmath>
 #include <mutex>
 #include <utility>
@@ -21,34 +23,40 @@ AudioProducer::~AudioProducer() {
 }
 
 void AudioProducer::produce() {
-  std::vector<std::pair<std::int16_t, std::int16_t>> samples;
+  try {
+    std::vector<std::pair<std::int16_t, std::int16_t>> samples;
 
-  for (std::uint64_t p = 0, m = static_cast<std::uint64_t>(
-                                std::ceil(m_max_stop_time_offset *
-                                          hisui::Constants::PCM_SAMPLE_RATE));
-       p < m; ++p) {
-    std::int16_t left = 0;
-    std::int16_t right = 0;
-    m_sequencer->getSamples(&samples, p);
-    for (const auto& s : samples) {
-      const auto [l, r] = s;
-      if (l != 0) {
-        left = m_mix_sample(left, l);
+    for (std::uint64_t p = 0, m = static_cast<std::uint64_t>(
+                                  std::ceil(m_max_stop_time_offset *
+                                            hisui::Constants::PCM_SAMPLE_RATE));
+         p < m; ++p) {
+      std::int16_t left = 0;
+      std::int16_t right = 0;
+      m_sequencer->getSamples(&samples, p);
+      for (const auto& s : samples) {
+        const auto [l, r] = s;
+        if (l != 0) {
+          left = m_mix_sample(left, l);
+        }
+        if (r != 0) {
+          right = m_mix_sample(right, r);
+        }
       }
-      if (r != 0) {
-        right = m_mix_sample(right, r);
+      {
+        std::lock_guard<std::mutex> lock(m_mutex_buffer);
+        m_encoder->addSample(left, right);
       }
     }
+
     {
       std::lock_guard<std::mutex> lock(m_mutex_buffer);
-      m_encoder->addSample(left, right);
+      m_encoder->flush();
+      m_is_finished = true;
     }
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(m_mutex_buffer);
-    m_encoder->flush();
+  } catch (const std::exception& e) {
+    spdlog::error("AudioProducer::produce() failed: what={}", e.what());
     m_is_finished = true;
+    throw e;
   }
 }
 

--- a/src/muxer/video_producer.hpp
+++ b/src/muxer/video_producer.hpp
@@ -24,10 +24,8 @@ class VideoProducer {
  public:
   virtual ~VideoProducer();
   void produce();
-
   void bufferPop();
   std::optional<hisui::Frame> bufferFront();
-
   bool isFinished();
 
   std::uint32_t getWidth() const;


### PR DESCRIPTION
WebM/MP4 のMuxer では 動画/音声を並行処理するために Video/AudioProducer::produce() を std::async() で起動している.
async() でできる Future を get() していなかったため例外が発生しても伝播せず,
WebM としておかしな入力ファイルなどでデコードに失敗した場合などでスタックしてしまっていた.

もともと Muxer は Producer の終了状況を polling しているので, Producer::produce() 全体を try-catch で囲み,
例外発生時は終了状態にした上で再 throw するようにした
そして Muxer で終了状態を検知したら, Future を get() するようにした