### PR TITLE
WebM/MP4 Muxer の mux() を共通化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ target_sources(hisui
     src/muxer/opus_audio_producer.cpp
     src/muxer/simple_mp4_muxer.cpp
     src/muxer/faststart_mp4_muxer.cpp
+    src/muxer/muxer.cpp
     src/muxer/video_producer.cpp
     src/muxer/vpx_video_producer.cpp
     src/util/interval.cpp

--- a/src/muxer/async_webm_muxer.cpp
+++ b/src/muxer/async_webm_muxer.cpp
@@ -1,18 +1,11 @@
 #include "muxer/async_webm_muxer.hpp"
 
-#include <cxxabi.h>
-#include <spdlog/spdlog.h>
-
 #include <array>
-#include <chrono>
+#include <cstdint>
 #include <filesystem>
-#include <future>
 #include <iterator>
-#include <optional>
 #include <stdexcept>
 #include <string>
-#include <system_error>
-#include <thread>
 
 #include "audio/opus.hpp"
 #include "constants.hpp"
@@ -73,101 +66,25 @@ AsyncWebMMuxer::~AsyncWebMMuxer() {
   delete m_audio_producer;
 }
 
-void AsyncWebMMuxer::addAndConsumeAudio(std::uint8_t* data,
-                                        const std::size_t data_length,
-                                        const std::uint64_t timestamp) {
-  m_context->addAudioFrame(data, data_length, timestamp);
-  delete[] data;
+void AsyncWebMMuxer::appendAudio(hisui::Frame frame) {
+  m_context->addAudioFrame(frame.data, frame.data_size, frame.timestamp);
+  delete[] frame.data;
   m_audio_producer->bufferPop();
 }
 
-void AsyncWebMMuxer::addAndConsumeVideo(std::uint8_t* data,
-                                        const std::size_t data_length,
-                                        const std::uint64_t timestamp,
-                                        const bool is_keyframe) {
-  m_context->addVideoFrame(data, data_length, timestamp, is_keyframe);
-  delete[] data;
+void AsyncWebMMuxer::appendVideo(hisui::Frame frame) {
+  m_context->addVideoFrame(frame.data, frame.data_size, frame.timestamp,
+                           frame.is_key);
+  delete[] frame.data;
   m_video_producer->bufferPop();
 }
 
 void AsyncWebMMuxer::run() {
-  auto video_future = std::async(std::launch::async, &VPXVideoProducer::produce,
-                                 m_video_producer);
-
-  auto audio_future = std::async(std::launch::async,
-                                 &OpusAudioProducer::produce, m_audio_producer);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-  bool video_finished = false;
-
-  while (!m_audio_producer->isFinished()) {
-    const auto audio_front = m_audio_producer->bufferFront();
-    if (!audio_front.has_value()) {
-      spdlog::debug("audio queue is empty");
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      continue;
-    }
-    const auto audio_timestamp = audio_front.value().timestamp;
-
-    if (video_finished) {
-      addAndConsumeAudio(audio_front.value().data,
-                         audio_front.value().data_size, audio_timestamp);
-      continue;
-    }
-
-    if (m_video_producer->isFinished()) {
-      video_finished = true;
-      video_future.get();
-      spdlog::debug("video was processed");
-      addAndConsumeAudio(audio_front.value().data,
-                         audio_front.value().data_size, audio_timestamp);
-      continue;
-    }
-
-    const auto video_front = m_video_producer->bufferFront();
-    if (!video_front.has_value()) {
-      spdlog::debug("video queue is empty (1)");
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      continue;
-    }
-    const auto video_timestamp = video_front.value().timestamp;
-
-    if (video_timestamp <= audio_timestamp) {
-      addAndConsumeVideo(video_front.value().data,
-                         video_front.value().data_size, video_timestamp,
-                         video_front.value().is_key);
-      continue;
-    }
-    addAndConsumeAudio(audio_front.value().data, audio_front.value().data_size,
-                       audio_timestamp);
-  }
-
-  audio_future.get();
-  spdlog::debug("audio was processed");
-
-  if (video_finished) {
-    return;
-  }
-
-  spdlog::debug("video is processing");
-  while (!m_video_producer->isFinished()) {
-    const auto video_front = m_video_producer->bufferFront();
-    if (!video_front.has_value()) {
-      spdlog::debug("video queue is empty (2)");
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      continue;
-    }
-
-    addAndConsumeVideo(video_front.value().data, video_front.value().data_size,
-                       video_front.value().timestamp,
-                       video_front.value().is_key);
-  }
-
-  video_future.get();
-  spdlog::debug("video was processed");
-}  // namespace hisui::muxer
+  mux();
+}
 
 void AsyncWebMMuxer::cleanUp() {}
+
+void AsyncWebMMuxer::muxFinalize() {}
 
 }  // namespace hisui::muxer

--- a/src/muxer/async_webm_muxer.hpp
+++ b/src/muxer/async_webm_muxer.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
-#include <cstdint>
 #include <cstdio>
-#include <fstream>
 
 #include "config.hpp"
 #include "metadata.hpp"
 #include "muxer/muxer.hpp"
+
+namespace hisui {
+
+struct Frame;
+
+}
 
 namespace hisui::webm::output {
 
@@ -15,9 +19,6 @@ class Context;
 }  // namespace hisui::webm::output
 
 namespace hisui::muxer {
-
-class AudioProducer;
-class VideoProducer;
 
 class AsyncWebMMuxer : public Muxer {
  public:
@@ -29,22 +30,15 @@ class AsyncWebMMuxer : public Muxer {
   void cleanUp() override;
 
  private:
+  void muxFinalize() override;
+  void appendAudio(hisui::Frame) override;
+  void appendVideo(hisui::Frame) override;
+
   hisui::webm::output::Context* m_context;
   std::FILE* m_file;
 
   hisui::Config m_config;
   hisui::Metadata m_metadata;
-
-  VideoProducer* m_video_producer;
-  AudioProducer* m_audio_producer;
-
-  void addAndConsumeAudio(std::uint8_t*,
-                          const std::size_t,
-                          const std::uint64_t);
-  void addAndConsumeVideo(std::uint8_t*,
-                          const std::size_t,
-                          const std::uint64_t,
-                          const bool);
 };
 
 }  // namespace hisui::muxer

--- a/src/muxer/mp4_muxer.cpp
+++ b/src/muxer/mp4_muxer.cpp
@@ -1,17 +1,12 @@
 #include "muxer/mp4_muxer.hpp"
 
-#include <cxxabi.h>
-#include <spdlog/spdlog.h>
-
-#include <chrono>
+#include <cstdint>
 #include <filesystem>
-#include <future>
 #include <iterator>
-#include <optional>
 #include <string>
-#include <system_error>
-#include <thread>
 #include <vector>
+
+#include <boost/rational.hpp>
 
 #include "config.hpp"
 #include "constants.hpp"
@@ -94,6 +89,9 @@ void MP4Muxer::initialize(const hisui::Config& config_orig,
        .width = m_video_producer->getWidth(),
        .height = m_video_producer->getHeight(),
        .writer = m_writer});
+
+  m_timescale_ratio.assign(m_soun_track->getTimescale(),
+                           m_vide_track->getTimescale());
 }
 
 MP4Muxer::~MP4Muxer() {
@@ -105,7 +103,7 @@ MP4Muxer::~MP4Muxer() {
   delete m_audio_producer;
 }
 
-void MP4Muxer::addAudioBuffer(hisui::Frame frame) {
+void MP4Muxer::appendAudio(hisui::Frame frame) {
   if ((frame.timestamp * m_writer->getMvhdTimescale() /
        m_soun_track->getTimescale()) >= m_chunk_start + m_chunk_interval) {
     m_chunk_start += m_chunk_interval;
@@ -116,7 +114,7 @@ void MP4Muxer::addAudioBuffer(hisui::Frame frame) {
   m_audio_producer->bufferPop();
 }
 
-void MP4Muxer::addVideoBuffer(hisui::Frame frame) {
+void MP4Muxer::appendVideo(hisui::Frame frame) {
   if ((frame.timestamp * m_writer->getMvhdTimescale() /
        m_vide_track->getTimescale()) >= m_chunk_start + m_chunk_interval) {
     m_chunk_start += m_chunk_interval;
@@ -142,75 +140,7 @@ void MP4Muxer::writeTrackData() {
   m_video_buffer.clear();
 }
 
-void MP4Muxer::mux() {
-  auto video_future =
-      std::async(std::launch::async, &VideoProducer::produce, m_video_producer);
-
-  auto audio_future =
-      std::async(std::launch::async, &AudioProducer::produce, m_audio_producer);
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-  bool video_finished = false;
-
-  while (!m_audio_producer->isFinished()) {
-    const auto audio_front = m_audio_producer->bufferFront();
-    if (!audio_front.has_value()) {
-      spdlog::debug("audio queue is empty");
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      continue;
-    }
-    const auto audio_timestamp = audio_front.value().timestamp;
-
-    if (video_finished) {
-      addAudioBuffer(audio_front.value());
-      continue;
-    }
-
-    if (m_video_producer->isFinished()) {
-      video_future.get();
-      spdlog::debug("video was processed");
-      video_finished = true;
-      addAudioBuffer(audio_front.value());
-      continue;
-    }
-
-    const auto video_front = m_video_producer->bufferFront();
-    if (!video_front.has_value()) {
-      spdlog::debug("video queue is empty (1)");
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      continue;
-    }
-    const auto video_timestamp = video_front.value().timestamp *
-                                 m_soun_track->getTimescale() /
-                                 m_vide_track->getTimescale();
-
-    if (video_timestamp <= audio_timestamp) {
-      addVideoBuffer(video_front.value());
-      continue;
-    }
-    addAudioBuffer(audio_front.value());
-  }
-
-  audio_future.get();
-  spdlog::debug("audio was processed");
-
-  if (!video_finished) {
-    spdlog::debug("video is processing");
-    while (!m_video_producer->isFinished()) {
-      const auto video_front = m_video_producer->bufferFront();
-      if (!video_front.has_value()) {
-        spdlog::debug("video queue is empty (2)");
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        continue;
-      }
-
-      addVideoBuffer(video_front.value());
-    }
-    video_future.get();
-    spdlog::debug("video was processed");
-  }
-
+void MP4Muxer::muxFinalize() {
   writeTrackData();
 }
 

--- a/src/muxer/mp4_muxer.hpp
+++ b/src/muxer/mp4_muxer.hpp
@@ -29,9 +29,6 @@ class Writer;
 
 namespace hisui::muxer {
 
-class AudioProducer;
-class VideoProducer;
-
 class MP4Muxer : public Muxer {
  public:
   ~MP4Muxer();
@@ -43,17 +40,14 @@ class MP4Muxer : public Muxer {
   shiguredo::mp4::track::SounTrack* m_soun_track;
   std::uint64_t m_chunk_interval;
 
-  VideoProducer* m_video_producer;
-  AudioProducer* m_audio_producer;
-
   std::uint64_t m_chunk_start = 0;
   std::vector<hisui::Frame> m_audio_buffer;
   std::vector<hisui::Frame> m_video_buffer;
 
-  void addAudioBuffer(hisui::Frame);
-  void addVideoBuffer(hisui::Frame);
+  void muxFinalize() override;
+  void appendAudio(hisui::Frame) override;
+  void appendVideo(hisui::Frame) override;
 
-  void mux();
   void writeTrackData();
   void initialize(const hisui::Config& t_config,
                   const hisui::Metadata& t_metadata,

--- a/src/muxer/muxer.cpp
+++ b/src/muxer/muxer.cpp
@@ -1,0 +1,96 @@
+#include "muxer/muxer.hpp"
+
+#include <cxxabi.h>
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <future>
+#include <optional>
+#include <system_error>
+#include <thread>
+
+#include <boost/exception/exception.hpp>
+#include <boost/rational.hpp>
+
+#include "frame.hpp"
+#include "muxer/audio_producer.hpp"
+#include "muxer/video_producer.hpp"
+
+namespace hisui::muxer {
+
+void Muxer::mux() {
+  auto video_future =
+      std::async(std::launch::async, &VideoProducer::produce, m_video_producer);
+
+  auto audio_future =
+      std::async(std::launch::async, &AudioProducer::produce, m_audio_producer);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  bool video_finished = false;
+
+  while (!m_audio_producer->isFinished()) {
+    const auto audio_front = m_audio_producer->bufferFront();
+    if (!audio_front.has_value()) {
+      spdlog::debug("audio queue is empty");
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      continue;
+    }
+    const auto audio_timestamp = audio_front.value().timestamp;
+
+    if (video_finished) {
+      appendAudio(audio_front.value());
+      continue;
+    }
+
+    if (m_video_producer->isFinished()) {
+      video_finished = true;
+      video_future.get();
+      spdlog::debug("video was processed");
+      appendAudio(audio_front.value());
+      continue;
+    }
+
+    const auto video_front = m_video_producer->bufferFront();
+    if (!video_front.has_value()) {
+      spdlog::debug("video queue is empty (1)");
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      continue;
+    }
+    const auto video_timestamp =
+        video_front.value().timestamp * m_timescale_ratio;
+
+    if (video_timestamp <= audio_timestamp) {
+      appendVideo(video_front.value());
+      continue;
+    }
+    appendAudio(audio_front.value());
+  }
+
+  audio_future.get();
+  spdlog::debug("audio was processed");
+
+  if (video_finished) {
+    muxFinalize();
+    return;
+  }
+
+  spdlog::debug("video is processing");
+  while (!m_video_producer->isFinished()) {
+    const auto video_front = m_video_producer->bufferFront();
+    if (!video_front.has_value()) {
+      spdlog::debug("video queue is empty (2)");
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      continue;
+    }
+
+    appendVideo(video_front.value());
+  }
+
+  video_future.get();
+  spdlog::debug("video was processed");
+
+  muxFinalize();
+}
+
+}  // namespace hisui::muxer

--- a/src/muxer/muxer.hpp
+++ b/src/muxer/muxer.hpp
@@ -1,6 +1,19 @@
 #pragma once
 
+#include <cstdint>
+
+#include <boost/rational.hpp>
+
+namespace hisui {
+
+struct Frame;
+
+}
+
 namespace hisui::muxer {
+
+class AudioProducer;
+class VideoProducer;
 
 class Muxer {
  public:
@@ -8,6 +21,18 @@ class Muxer {
   virtual void setUp() = 0;
   virtual void run() = 0;
   virtual void cleanUp() = 0;
+
+ protected:
+  void mux();
+
+  VideoProducer* m_video_producer;
+  AudioProducer* m_audio_producer;
+  boost::rational<std::uint64_t> m_timescale_ratio = 1;
+
+ private:
+  virtual void muxFinalize() = 0;
+  virtual void appendAudio(hisui::Frame) = 0;
+  virtual void appendVideo(hisui::Frame) = 0;
 };
 
 }  // namespace hisui::muxer


### PR DESCRIPTION
WebM/MP4Muxer の mux() はほぼ同様のコードなので, 今後のために共通化しました

結合テストで以前と同様のファイルを出力することを確認しています.

結合テストは次のように実施します

1. {hisuiのディレクトリ}/release を作成
2. release に移動
3. `cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_FDK_AAC=YES`
4. make
5. {hisuiのディレクトリ}/test/integration に移動
6. make (初回は外部からファイルを持ってくるので時間がかかります)

mp4 は faketime で時間を固定して比較しています.
webm はクラスター部分を抽出して比較しています.
