### PR TITLE
--libvp9-tile-columns コマンドラインオプションの追加と適用

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -183,7 +183,7 @@ void set_cli_options(CLI::App* app, Config* config) {
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--libvp9-frame-parallel", config->libvp9_frame_parallel,
-                  "libvp9 rame parallel decodability features "
+                  "libvp9 frame parallel decodability features "
                   "default: 1")
       ->check(CLI::Range(0, 1))
       ->group(OPTIONS_FOR_TUNING);
@@ -192,6 +192,12 @@ void set_cli_options(CLI::App* app, Config* config) {
                   "libvpx cpu used (-16, 16) "
                   "default: 4")
       ->check(CLI::Range(-16, 16))
+      ->group(OPTIONS_FOR_TUNING);
+
+  app->add_option("--libvp9-tile-columns", config->libvp9_tile_columns,
+                  "libvp9 number of tile columns to use, log2 "
+                  "default: 0 (0, 6)")
+      ->check(CLI::Range(0, 6))
       ->group(OPTIONS_FOR_TUNING);
 
   std::vector<std::pair<std::string, spdlog::level::level_enum>>

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -95,6 +95,7 @@ class Config {
   std::uint32_t libvpx_threads = 0;
   std::int32_t libvpx_cpu_used = 4;
   std::uint32_t libvp9_frame_parallel = 1;
+  std::uint32_t libvp9_tile_columns = 0;
 
   libyuv::FilterMode libyuv_filter_mode = libyuv::kFilterBox;
 

--- a/src/video/vpx.cpp
+++ b/src/video/vpx.cpp
@@ -38,7 +38,8 @@ VPXEncoderConfig::VPXEncoderConfig(const std::uint32_t t_width,
       max_q(config.libvpx_max_q),
       threads(config.libvpx_threads),
       frame_parallel(config.libvp9_frame_parallel),
-      cpu_used(config.libvpx_cpu_used) {}
+      cpu_used(config.libvpx_cpu_used),
+      tile_columns(config.libvp9_tile_columns) {}
 
 void update_yuv_image_by_vpx_image(YUVImage* yuv_image,
                                    const vpx_image_t* vpx_image) {
@@ -177,6 +178,8 @@ void create_vpx_codec_ctx_t_for_encoding(::vpx_codec_ctx_t* codec,
   if (config.fourcc == hisui::config::OutVideoCodec::VP9) {
     ::vpx_codec_control(codec, VP9E_SET_FRAME_PARALLEL_DECODING,
                         config.frame_parallel);
+    ::vpx_codec_control(codec, VP9E_SET_TILE_COLUMNS,
+                        static_cast<int>(config.tile_columns));
   }
 }
 

--- a/src/video/vpx.hpp
+++ b/src/video/vpx.hpp
@@ -35,6 +35,7 @@ class VPXEncoderConfig {
   const std::uint32_t threads;
   const std::uint32_t frame_parallel;
   const std::int32_t cpu_used;
+  const std::uint32_t tile_columns;
 };
 
 void update_yuv_image_by_vpx_image(YUVImage*, const ::vpx_image_t*);


### PR DESCRIPTION
性能のチューニングのために libvpx の tile-columns (vp9 専用) を指定できるようにしました