### PR TITLE
ghcr.io へのアクセスに CR_PAT ではなく GITHUB_TOKEN を利用する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Push to ghcr.io


### PR DESCRIPTION
https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/

2021.2 リリース時に確認する