### PR TITLE
結合テストのため, --libvp9-tile-columns のデフォルト値を変更

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -95,7 +95,7 @@ class Config {
   std::uint32_t libvpx_threads = 0;
   std::int32_t libvpx_cpu_used = 4;
   std::uint32_t libvp9_frame_parallel = 1;
-  std::uint32_t libvp9_tile_columns = 0;
+  std::uint32_t libvp9_tile_columns = 6;
 
   libyuv::FilterMode libyuv_filter_mode = libyuv::kFilterBox;
 


### PR DESCRIPTION
--libvp9-tile-columns オプションの追加により結合テストがこわれているので是正します
