### PR TITLE
hisui::webm::input::Context に FILE* ではなく string(file_path) を渡すようにする

### DIFF
--- a/src/audio/webm_source.cpp
+++ b/src/audio/webm_source.cpp
@@ -15,19 +15,13 @@
 
 namespace hisui::audio {
 
-WebMSource::WebMSource(const std::string& file_path) {
-  m_file = std::fopen(file_path.c_str(), "rb");
-  if (m_file == nullptr) {
-    throw std::runtime_error("Unable to open: " + file_path);
-  }
-
-  m_webm = new hisui::webm::input::AudioContext();
-  if (!m_webm->init(m_file)) {
+WebMSource::WebMSource(const std::string& t_file_path) {
+  m_webm = new hisui::webm::input::AudioContext(t_file_path);
+  if (!m_webm->init()) {
     spdlog::info(
         "AudioContext initialization failed. no audio track or unsupported "
         "codec: file_path='{}'",
-        file_path);
-    std::fclose(m_file);
+        t_file_path);
     delete m_webm;
     m_webm = nullptr;
     return;
@@ -41,10 +35,9 @@ WebMSource::WebMSource(const std::string& file_path) {
       break;
     default:
       // 対応していない WebM の場合は {0, 0} を返す
-      std::fclose(m_file);
       delete m_webm;
       m_webm = nullptr;
-      spdlog::info("unsupported audio codec: file_path ='{}'", file_path);
+      spdlog::info("unsupported audio codec: file_path ='{}'", t_file_path);
       return;
   }
 }
@@ -52,7 +45,6 @@ WebMSource::WebMSource(const std::string& file_path) {
 WebMSource::~WebMSource() {
   if (m_webm) {
     delete m_webm;
-    std::fclose(m_file);
   }
   if (m_decoder) {
     delete m_decoder;

--- a/src/audio/webm_source.hpp
+++ b/src/audio/webm_source.hpp
@@ -31,7 +31,6 @@ class WebMSource : public Source {
   std::uint64_t m_sampling_rate;
   std::queue<std::int16_t> m_data;
   std::uint64_t m_current_position = 0;
-  std::FILE* m_file;
 
   void readFrame();
 };

--- a/src/video/webm_source.cpp
+++ b/src/video/webm_source.cpp
@@ -18,20 +18,14 @@
 
 namespace hisui::video {
 
-WebMSource::WebMSource(const std::string& file_path) {
-  m_file = std::fopen(file_path.c_str(), "rb");
-  if (m_file == nullptr) {
-    throw std::runtime_error("Unable to open: " + file_path);
-  }
-
-  m_webm = new hisui::webm::input::VideoContext();
-  if (!m_webm->init(m_file)) {
+WebMSource::WebMSource(const std::string& t_file_path) {
+  m_webm = new hisui::webm::input::VideoContext(t_file_path);
+  if (!m_webm->init()) {
     spdlog::info(
         "VideoContext initialization failed. no video track or unsupported "
         "codec: file_path={}",
-        file_path);
+        t_file_path);
 
-    std::fclose(m_file);
     delete m_webm;
     m_webm = nullptr;
     m_width = 320;
@@ -43,7 +37,7 @@ WebMSource::WebMSource(const std::string& file_path) {
   m_width = m_webm->getWidth();
   m_height = m_webm->getHeight();
 
-  spdlog::trace("WebMSource: file_path={}, width={}, height={}", file_path,
+  spdlog::trace("WebMSource: file_path={}, width={}, height={}", t_file_path,
                 m_width, m_height);
 
   m_duration = static_cast<std::uint64_t>(m_webm->getDuration());
@@ -62,7 +56,6 @@ WebMSource::WebMSource(const std::string& file_path) {
       throw std::runtime_error("openh264 library is not loaded");
     default:
       const auto fourcc = m_webm->getFourcc();
-      std::fclose(m_file);
       delete m_webm;
       m_webm = nullptr;
       throw std::runtime_error(fmt::format("unknown fourcc: {}", fourcc));
@@ -72,7 +65,6 @@ WebMSource::WebMSource(const std::string& file_path) {
 WebMSource::~WebMSource() {
   if (m_webm) {
     delete m_webm;
-    std::fclose(m_file);
   }
   if (m_decoder) {
     delete m_decoder;

--- a/src/video/webm_source.hpp
+++ b/src/video/webm_source.hpp
@@ -32,7 +32,6 @@ class WebMSource : public Source {
   std::uint32_t m_width;
   std::uint32_t m_height;
   std::uint64_t m_duration;
-  std::FILE* m_file;
 
   void readFrame();
 };

--- a/src/webm/input/audio_context.cpp
+++ b/src/webm/input/audio_context.cpp
@@ -7,10 +7,12 @@
 
 #include <cstddef>
 #include <cstring>
+#include "webm/input/context.hpp"
 
 namespace hisui::webm::input {
 
-AudioContext::AudioContext() {}
+AudioContext::AudioContext(const std::string& t_file_path)
+    : Context(t_file_path) {}
 
 AudioContext::~AudioContext() {
   reset();
@@ -24,8 +26,13 @@ void AudioContext::reset() {
   m_codec = AudioCodec::None;
 }
 
-bool AudioContext::init(std::FILE* file) {
-  initReaderAndSegment(file);
+bool AudioContext::init() {
+  m_file = std::fopen(m_file_path.c_str(), "rb");
+  if (m_file == nullptr) {
+    throw std::runtime_error("Unable to open: " + m_file_path);
+  }
+
+  initReaderAndSegment(m_file);
 
   const mkvparser::Tracks* const tracks = m_segment->GetTracks();
   const mkvparser::AudioTrack* audio_track = nullptr;

--- a/src/webm/input/audio_context.cpp
+++ b/src/webm/input/audio_context.cpp
@@ -47,7 +47,6 @@ bool AudioContext::init() {
 
   if (audio_track == nullptr || audio_track->GetCodecId() == nullptr) {
     spdlog::info("audio track not found");
-    reset();
     return false;
   }
 
@@ -67,7 +66,6 @@ bool AudioContext::init() {
     }
   } else {
     spdlog::info("unsuppoted codec: codec_id={}", audio_track->GetCodecId());
-    reset();
     return false;
   }
 

--- a/src/webm/input/audio_context.hpp
+++ b/src/webm/input/audio_context.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <string>
 
 #include "webm/input/context.hpp"
 
@@ -14,11 +15,11 @@ enum struct AudioCodec {
 
 class AudioContext : public Context {
  public:
-  AudioContext();
+  explicit AudioContext(const std::string&);
   ~AudioContext();
 
   void reset();
-  bool init(std::FILE*);
+  bool init();
   int getChannels() const;
   std::uint64_t getBitDepth() const;
   double getSamplingRate() const;

--- a/src/webm/input/context.cpp
+++ b/src/webm/input/context.cpp
@@ -30,6 +30,10 @@ void Context::reset() {
   m_timestamp_ns = 0;
   m_track_index = 0;
   m_is_key_frame = false;
+  if (m_file) {
+    std::fclose(m_file);
+    m_file = nullptr;
+  }
 }
 
 void Context::initReaderAndSegment(std::FILE* file) {
@@ -115,7 +119,7 @@ void Context::rewindCluster() {
   m_reached_eos = false;
 }
 
-Context::Context() {}
+Context::Context(const std::string& t_file_path) : m_file_path(t_file_path) {}
 Context::~Context() {
   reset();
 }
@@ -166,6 +170,10 @@ std::int64_t Context::getTimestamp() const {
 
 std::int64_t Context::getDuration() const {
   return m_segment->GetDuration();
+}
+
+std::string Context::getFilePath() const {
+  return m_file_path;
 }
 
 };  // namespace hisui::webm::input

--- a/src/webm/input/context.hpp
+++ b/src/webm/input/context.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <string>
 
 namespace mkvparser {
 
@@ -18,12 +19,13 @@ namespace hisui::webm::input {
 
 class Context {
  public:
-  Context();
+  explicit Context(const std::string&);
   virtual ~Context();
 
-  virtual bool init(std::FILE*) = 0;
+  virtual bool init() = 0;
   std::size_t getBufferSize() const;
   unsigned char* getBuffer();
+  std::string getFilePath() const;
   std::int64_t getTimestamp() const;
   std::int64_t getDuration() const;
   bool readFrame();
@@ -32,6 +34,8 @@ class Context {
   mkvparser::Segment* m_segment = nullptr;
   const mkvparser::Cluster* m_cluster = nullptr;
   int m_track_index = 0;
+  std::string m_file_path;
+  std::FILE* m_file = nullptr;
 
   void reset();
   void initReaderAndSegment(std::FILE*);

--- a/src/webm/input/video_context.cpp
+++ b/src/webm/input/video_context.cpp
@@ -6,12 +6,15 @@
 #include <spdlog/spdlog.h>
 
 #include <cstring>
+#include <string>
 
 #include "constants.hpp"
+#include "webm/input/context.hpp"
 
 namespace hisui::webm::input {
 
-VideoContext::VideoContext() {}
+VideoContext::VideoContext(const std::string& t_file_path)
+    : Context(t_file_path) {}
 
 VideoContext::~VideoContext() {
   reset();
@@ -22,8 +25,12 @@ void VideoContext::reset() {
   m_fourcc = 0;
 }
 
-bool VideoContext::init(std::FILE* file) {
-  initReaderAndSegment(file);
+bool VideoContext::init() {
+  m_file = std::fopen(m_file_path.c_str(), "rb");
+  if (m_file == nullptr) {
+    throw std::runtime_error("Unable to open: " + m_file_path);
+  }
+  initReaderAndSegment(m_file);
 
   const mkvparser::Tracks* const tracks = m_segment->GetTracks();
   const mkvparser::VideoTrack* video_track = nullptr;

--- a/src/webm/input/video_context.cpp
+++ b/src/webm/input/video_context.cpp
@@ -45,7 +45,6 @@ bool VideoContext::init() {
 
   if (video_track == nullptr || video_track->GetCodecId() == nullptr) {
     spdlog::info("video track not found");
-    reset();
     return false;
   }
 
@@ -59,7 +58,6 @@ bool VideoContext::init() {
     const auto codec_name_as_utf8 = video_track->GetCodecNameAsUTF8();
     if (codec_name_as_utf8 == nullptr) {
       spdlog::info("V_MPEG4/ISO/AVC: codec_name_as_utf8 is null");
-      reset();
       return false;
     }
     if (!std::strncmp(codec_name_as_utf8, "H.264", 5)) {
@@ -67,7 +65,6 @@ bool VideoContext::init() {
     } else {
       spdlog::info("V_MPEG4/ISO/AVC: unknown codec_name_as_utf8: {}",
                    codec_name_as_utf8);
-      reset();
       return false;
     }
   } else {
@@ -78,7 +75,6 @@ bool VideoContext::init() {
                    video_track->GetCodecId(),
                    video_track->GetCodecNameAsUTF8());
     }
-    reset();
     return false;
   }
 

--- a/src/webm/input/video_context.hpp
+++ b/src/webm/input/video_context.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <string>
 
 #include "webm/input/context.hpp"
 
@@ -9,12 +10,12 @@ namespace hisui::webm::input {
 
 class VideoContext : public Context {
  public:
-  VideoContext();
+  explicit VideoContext(const std::string&);
   ~VideoContext();
 
   void reset();
 
-  bool init(std::FILE*);
+  bool init();
 
   std::uint32_t getFourcc() const;
   std::uint32_t getWidth() const;


### PR DESCRIPTION
デコード時にデコーダー内でレポーティングを行なうのに, webm::input::Context に file_path が渡されていないと不便なので, 
file_path を渡すようにしファイルリソースの管理方法を変更しました.

また Context::init() 失敗時には Context を delete している(この際 Context::reset() が呼ばれる) ので, init() 内のでの reset() を除きました.