### PR TITLE
USE.md を hisui2021.2.1 のアップデートに合わせて修正しました

### DIFF
--- a/doc/USE.md
+++ b/doc/USE.md
@@ -12,7 +12,7 @@ Hisui は docker image を用意しています。これを使うことで x86_6
 - https://github.com/orgs/shiguredo/packages/container/package/hisui
 
 ```
-docker run -v /home/shiguredo/sora-2020.3/archive:/hisui ghcr.io/shiguredo/hisui:2021.1 -f /hisui/CSX77QY9F57V5BT72S62C28VS4.json
+docker run -v /home/shiguredo/sora-2020.3/archive:/hisui ghcr.io/shiguredo/hisui:2021.2.1 -f /hisui/CSX77QY9F57V5BT72S62C28VS4/report-CSX77QY9F57V5BT72S62C28VS4.json
 ```
 
 - -v で Sora の録画データがある archive フォルダを指定して下さい
@@ -23,7 +23,7 @@ docker run -v /home/shiguredo/sora-2020.3/archive:/hisui ghcr.io/shiguredo/hisui
 ## docker 経由で help を見る
 
 ```
-$ docker run ghcr.io/shiguredo/hisui:2021.1 hisui --help
+$ docker run ghcr.io/shiguredo/hisui:2021.2.1 hisui --help
 hisui
 Usage: /usr/local/bin/hisui [OPTIONS]
 
@@ -44,6 +44,7 @@ Options:
   --dir-for-faststart         Directory for intermediate files of faststart muxer. default: metadata directory
   --openh264                  OpenH264 dynamic library path
   --verbose                   Verbose mode
+  --audio-only                Audio only mode
   --show-progress-bar         Toggle to show progress bar. default: true
 ```
 
@@ -54,5 +55,5 @@ Options:
 -f で合成したい recording.report が生成するファイルを指定して下さい。
 
 ```
-./hisui -f CSX77QY9F57V5BT72S62C28VS4.json
+./hisui -f report-CSX77QY9F57V5BT72S62C28VS4.json
 ```


### PR DESCRIPTION
- docker で実行する際に指定する hisui を 2021.2.1 に修正しました
- 合成したいファイルを sora の仕様に合わせたパスとファイル名に修正しました
- help で出力する情報を hisui 2021.2.1 に合わせるよう修正しました