### PR TITLE
[実験的機能] 画面共有合成機能

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ target_sources(hisui
     src/muxer/async_webm_muxer.cpp
     src/muxer/audio_producer.cpp
     src/muxer/mp4_muxer.cpp
+    src/muxer/multi_channel_vpx_video_producer.cpp
     src/muxer/opus_audio_producer.cpp
     src/muxer/simple_mp4_muxer.cpp
     src/muxer/faststart_mp4_muxer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ target_sources(hisui
     src/video/composer.cpp
     src/video/decoder.cpp
     src/video/grid_composer.cpp
+    src/video/multi_channel_sequencer.cpp
     src/video/openh264.cpp
     src/video/openh264_decoder.cpp
     src/video/openh264_handler.cpp

--- a/src/audio/basic_sequencer.cpp
+++ b/src/audio/basic_sequencer.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <filesystem>
+#include <string>
 
 #include "audio/webm_source.hpp"
 #include "constants.hpp"

--- a/src/audio/basic_sequencer.cpp
+++ b/src/audio/basic_sequencer.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <filesystem>
-#include <string>
 
 #include "audio/webm_source.hpp"
 #include "constants.hpp"

--- a/src/audio/basic_sequencer.hpp
+++ b/src/audio/basic_sequencer.hpp
@@ -7,16 +7,11 @@
 
 #include "audio/sequencer.hpp"
 #include "audio/source.hpp"
+#include "util/interval.hpp"
 
 namespace hisui {
 
 class Archive;
-
-}
-
-namespace hisui::util {
-
-class Interval;
 
 }
 

--- a/src/audio/webm_source.cpp
+++ b/src/audio/webm_source.cpp
@@ -4,9 +4,8 @@
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
-#include <cstdio>
+#include <cstddef>
 #include <iterator>
-#include <stdexcept>
 
 #include "audio/decoder.hpp"
 #include "audio/opus_decoder.hpp"

--- a/src/audio/webm_source.hpp
+++ b/src/audio/webm_source.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include <queue>
 #include <string>
 #include <utility>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,6 +17,8 @@
 #include <CLI/Validators.hpp>
 #include <boost/rational.hpp>
 
+#define EXPERIMENTAL_OPTIONS "Experimental Options"
+
 #ifdef NDEBUG
 #define OPTIONS_FOR_TUNING ""
 #define OPTIONS_FOR_DEVELOPING ""
@@ -64,28 +66,33 @@ void set_cli_options(CLI::App* app, Config* config) {
 
   app->add_option("--screen-capture-report",
                   config->screen_capture_metadata_filename,
-                  "Multi Channel Metadata filename")
-      ->check(CLI::ExistingFile);
+                  "Screen Capture Metadata filename")
+      ->check(CLI::ExistingFile)
+      ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option("--screen-capture-width", config->screen_capture_width,
-                  "Width for screen-capture (960)");
+                  "Width for screen-capture. default: 960")
+      ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option("--screen-capture-height", config->screen_capture_height,
-                  "Height for screen-capture (640)");
+                  "Height for screen-capture. default: 640")
+      ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option("--screen-capture-bit-rate", config->screen_capture_bit_rate,
-                  "Bit rate for screen-capture (1000)");
+                  "Bit rate for screen-capture (kbps). default: 1000")
+      ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option("--mix-screen-capture-audio",
                   config->mix_screen_capture_audio,
-                  "Mix screen-capture audio (false)");
+                  "Mix screen-capture audio. default: false)")
+      ->group(EXPERIMENTAL_OPTIONS);
 
   std::vector<std::pair<std::string, config::OutContainer>> out_container_assoc{
       {"WebM", config::OutContainer::WebM},
       {"MP4", config::OutContainer::MP4},
   };
   app->add_option("--out-container", config->out_container,
-                  "Output container type (WebM/MP4) default: WebM")
+                  "Output container type (WebM/MP4). default: WebM")
       ->transform(
           CLI::CheckedTransformer(out_container_assoc, CLI::ignore_case));
 
@@ -94,7 +101,7 @@ void set_cli_options(CLI::App* app, Config* config) {
       {"VP9", config::OutVideoCodec::VP9},
   };
   app->add_option("--out-video-codec", config->out_video_codec,
-                  "Video codec (VP8/VP9) default: VP9")
+                  "Video codec (VP8/VP9). default: VP9")
       ->transform(CLI::CheckedTransformer(out_video_codec_assoc));
 
   std::vector<std::pair<std::string, config::OutAudioCodec>> out_audio_codec{
@@ -105,7 +112,7 @@ void set_cli_options(CLI::App* app, Config* config) {
 #endif
   };
   app->add_option("--out-audio-codec", config->out_audio_codec,
-                  "Audio codec (Opus/AAC) default: Opus (hisui supports "
+                  "Audio codec (Opus/AAC). default: Opus (hisui supports "
                   "AAC only in WebM)")
 #ifndef USE_FDK_AAC
       ->group("")
@@ -113,27 +120,27 @@ void set_cli_options(CLI::App* app, Config* config) {
       ->transform(CLI::CheckedTransformer(out_audio_codec, CLI::ignore_case));
 
   app->add_option("--out-video-frame-rate", config->out_video_frame_rate,
-                  "Video frame rate (INTEGER/RATIONAL) default: 25)");
+                  "Video frame rate (INTEGER/RATIONAL). default: 25)");
 
   app->add_option("--out-webm-file", config->out_filename, "Output filename")
       ->group(OPTIONS_FOR_BACKWARD_COMPATIBILITY);
   app->add_option("--out-file", config->out_filename, "Output filename");
 
   app->add_option("--max-columns", config->max_columns,
-                  "Max columns (POSITIVE INTEGER) default: 3")
+                  "Max columns (POSITIVE INTEGER). default: 3")
       ->check(CLI::PositiveNumber);
 
   app->add_option(
          "--libvpx-cq-level", config->libvpx_cq_level,
-         "libvpx Constrained Quality level (NON NAGATIVE INTEGER) default: 10")
+         "libvpx Constrained Quality level (NON NAGATIVE INTEGER). default: 30")
       ->check(CLI::Range(0, 63));
   app->add_option(
          "--libvpx-min-q", config->libvpx_min_q,
-         "libvpx minimum (best) quantizer (NON NEGATIVE INTEGER) default: 3")
+         "libvpx minimum (best) quantizer (NON NEGATIVE INTEGER). default: 10")
       ->check(CLI::Range(0, 63));
   app->add_option(
          "--libvpx-max-q", config->libvpx_max_q,
-         "libvpx maximum (worst) quantizer (NON NEGATIVE INTEGER) default: 40")
+         "libvpx maximum (worst) quantizer (NON NEGATIVE INTEGER). default: 50")
       ->check(CLI::Range(0, 63));
 
   app->add_option("--out-opus-bit-rate", config->out_opus_bit_rate,
@@ -176,13 +183,13 @@ void set_cli_options(CLI::App* app, Config* config) {
   app->add_option(
          "--scaling-width", config->scaling_width,
          "Scaling width per grid (NON NAGATIVE multiple of 4. auto mode: "
-         "0) default: 320")
+         "0). default: 320")
       ->check(NonNegativeMultipleOf4)
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--scaling-height", config->scaling_height,
                   "Scaling height per grid (NON NAGATIVE multiple of 4, auto "
-                  "mode: 0) default: 240")
+                  "mode: 0). default: 240")
       ->check(NonNegativeMultipleOf4)
       ->group(OPTIONS_FOR_TUNING);
 
@@ -194,37 +201,37 @@ void set_cli_options(CLI::App* app, Config* config) {
           {"box", libyuv::kFilterBox},
       };
   app->add_option("--libyuv-filter-mode", config->libyuv_filter_mode,
-                  "libyuv filter mode (none/linear/bilinear/box) default: box")
+                  "libyuv filter mode (none/linear/bilinear/box). default: box")
       ->transform(
           CLI::CheckedTransformer(libyuv_filter_mode_assoc, CLI::ignore_case))
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--libvpx-threads", config->libvpx_threads,
-                  "libvpx max number of threads (NON NEGATIVE INTEGER) "
+                  "libvpx max number of threads (NON NEGATIVE INTEGER). "
                   "default: 0 (use default)")
       ->check(CLI::NonNegativeNumber)
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--libvp9-frame-parallel", config->libvp9_frame_parallel,
-                  "libvp9 frame parallel decodability features "
+                  "libvp9 frame parallel decodability features. "
                   "default: 1")
       ->check(CLI::Range(0, 1))
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--libvpx-cpu-used", config->libvpx_cpu_used,
-                  "libvpx cpu used (-16, 16) "
+                  "libvpx cpu used (-16, 16). "
                   "default: 4")
       ->check(CLI::Range(-16, 16))
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--libvp9-tile-columns", config->libvp9_tile_columns,
-                  "libvp9 number of tile columns to use, log2 "
+                  "libvp9 number of tile columns to use, log2. "
                   "default: 0 (0, 6)")
       ->check(CLI::Range(0, 6))
       ->group(OPTIONS_FOR_TUNING);
 
   app->add_option("--libvp9-row-mt", config->libvp9_row_mt,
-                  "libvp9 row based non-deterministic multi-threading"
+                  "libvp9 row based non-deterministic multi-threading. "
                   "default: 0 (0, 1)")
       ->check(CLI::Range(0, 1))
       ->group(OPTIONS_FOR_TUNING);
@@ -241,7 +248,7 @@ void set_cli_options(CLI::App* app, Config* config) {
       };
   app->add_option(
          "-l,--log-level", config->log_level,
-         "Log level (trace/debug/info/warn/error/critical/off) default: info")
+         "Log level (trace/debug/info/warn/error/critical/off). default: info")
       ->transform(CLI::CheckedTransformer(log_level_assoc, CLI::ignore_case))
       ->group(OPTIONS_FOR_DEVELOPING);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -283,4 +283,11 @@ void set_cli_options(CLI::App* app, Config* config) {
       ->group(OPTIONS_FOR_DEVELOPING);
 }
 
+void Config::validate() const {
+  if (out_container == hisui::config::OutContainer::WebM &&
+      out_audio_codec == hisui::config::OutAudioCodec::FDK_AAC) {
+    throw std::runtime_error("hisui does not support AAC output in WebM");
+  }
+}
+
 }  // namespace hisui

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -70,16 +70,21 @@ void set_cli_options(CLI::App* app, Config* config) {
       ->check(CLI::ExistingFile)
       ->group(EXPERIMENTAL_OPTIONS);
 
-  app->add_option("--screen-capture-width", config->screen_capture_width,
-                  "Width for screen-capture. default: 960")
+  app->add_option(
+         "--screen-capture-width", config->screen_capture_width,
+         "Width for screen-capture (NON NAGATIVE multiple of 4). default: 960")
+      ->check(NonNegativeMultipleOf4)
       ->group(EXPERIMENTAL_OPTIONS);
 
-  app->add_option("--screen-capture-height", config->screen_capture_height,
-                  "Height for screen-capture. default: 640")
+  app->add_option(
+         "--screen-capture-height", config->screen_capture_height,
+         "Height for screen-capture (NON NAGATIVE multiple of 4). default: 640")
+      ->check(NonNegativeMultipleOf4)
       ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option("--screen-capture-bit-rate", config->screen_capture_bit_rate,
                   "Bit rate for screen-capture (kbps). default: 1000")
+      ->check(CLI::PositiveNumber)
       ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option("--mix-screen-capture-audio",

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,7 +1,7 @@
 #include "config.hpp"
 
 #include <libyuv/scale.h>
-#include <spdlog/spdlog.h>
+#include <spdlog/common.h>
 
 #include <functional>
 #include <memory>
@@ -11,8 +11,10 @@
 #include <vector>
 
 #include <CLI/App.hpp>
-#include <CLI/Config.hpp>
-#include <CLI/Formatter.hpp>
+#include <CLI/FormatterFwd.hpp>
+#include <CLI/Option.hpp>
+#include <CLI/TypeTools.hpp>
+#include <CLI/Validators.hpp>
 #include <boost/rational.hpp>
 
 #ifdef NDEBUG
@@ -59,6 +61,24 @@ void set_cli_options(CLI::App* app, Config* config) {
                   "Metadata filename (REQUIRED)")
       ->check(CLI::ExistingFile)
       ->required();
+
+  app->add_option("--screen-capture-report",
+                  config->screen_capture_metadata_filename,
+                  "Multi Channel Metadata filename")
+      ->check(CLI::ExistingFile);
+
+  app->add_option("--screen-capture-width", config->screen_capture_width,
+                  "Width for screen-capture (960)");
+
+  app->add_option("--screen-capture-height", config->screen_capture_height,
+                  "Height for screen-capture (640)");
+
+  app->add_option("--screen-capture-bit-rate", config->screen_capture_bit_rate,
+                  "Bit rate for screen-capture (1000)");
+
+  app->add_option("--mix-screen-capture-audio",
+                  config->mix_screen_capture_audio,
+                  "Mix screen-capture audio (false)");
 
   std::vector<std::pair<std::string, config::OutContainer>> out_container_assoc{
       {"WebM", config::OutContainer::WebM},
@@ -141,7 +161,9 @@ void set_cli_options(CLI::App* app, Config* config) {
                   "OpenH264 dynamic library path");
 
   app->add_flag("--verbose", config->verbose, "Verbose mode");
+
   app->add_flag("--audio-only", config->audio_only, "Audio only mode");
+
   app->add_option("--show-progress-bar", config->show_progress_bar,
                   "Toggle to show progress bar. default: true");
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -64,10 +64,17 @@ void set_cli_options(CLI::App* app, Config* config) {
       ->check(CLI::ExistingFile)
       ->required();
 
-  app->add_option("--screen-capture-report",
-                  config->screen_capture_metadata_filename,
-                  "Screen Capture Metadata filename")
-      ->check(CLI::ExistingFile)
+  auto option_screen_capture_report =
+      app->add_option("--screen-capture-report",
+                      config->screen_capture_metadata_filename,
+                      "Screen capture metadata filename")
+          ->check(CLI::ExistingFile)
+          ->group(EXPERIMENTAL_OPTIONS);
+
+  app->add_option("--screen-capture-connection-id",
+                  config->screen_capture_connection_id,
+                  "Screen capture connection id")
+      ->excludes(option_screen_capture_report)
       ->group(EXPERIMENTAL_OPTIONS);
 
   app->add_option(

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -61,6 +61,8 @@ enum struct OutAudioCodec {
 
 class Config {
  public:
+  void validate() const;
+
   std::string in_metadata_filename;
   std::string screen_capture_metadata_filename = "";
   config::OutVideoCodec out_video_codec = config::OutVideoCodec::VP9;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -62,6 +62,7 @@ enum struct OutAudioCodec {
 class Config {
  public:
   std::string in_metadata_filename;
+  std::string screen_capture_metadata_filename = "";
   config::OutVideoCodec out_video_codec = config::OutVideoCodec::VP9;
   config::OutContainer out_container = config::OutContainer::WebM;
   std::uint32_t out_video_bit_rate = 0;
@@ -93,6 +94,10 @@ class Config {
   std::uint32_t scaling_width = 320;
   std::uint32_t scaling_height = 240;
 
+  std::uint32_t screen_capture_width = 960;
+  std::uint32_t screen_capture_height = 640;
+  std::uint32_t screen_capture_bit_rate = 1000;
+
   std::uint32_t libvpx_threads = 0;
   std::int32_t libvpx_cpu_used = 8;
   std::uint32_t libvp9_frame_parallel = 1;
@@ -106,6 +111,7 @@ class Config {
   std::string openh264 = "";
 
   config::AudioMixer audio_mixer = config::AudioMixer::Simple;
+  bool mix_screen_capture_audio = false;
 
   config::MP4Muxer mp4_muxer = config::MP4Muxer::Faststart;
   config::OutAudioCodec out_audio_codec = config::OutAudioCodec::Opus;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -65,6 +65,7 @@ class Config {
 
   std::string in_metadata_filename;
   std::string screen_capture_metadata_filename = "";
+  std::string screen_capture_connection_id = "";
   config::OutVideoCodec out_video_codec = config::OutVideoCodec::VP9;
   config::OutContainer out_container = config::OutContainer::WebM;
   std::uint32_t out_video_bit_rate = 0;

--- a/src/hisui.cpp
+++ b/src/hisui.cpp
@@ -1,19 +1,14 @@
 #include <bits/exception.h>
+#include <spdlog/common.h>
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
-#include <fstream>
-#include <initializer_list>
-#include <iterator>
-#include <map>
 #include <stdexcept>
 #include <string>
-#include <vector>
 
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
-#include <boost/json.hpp>
 
 #include "config.hpp"
 #include "metadata.hpp"
@@ -44,24 +39,6 @@ int main(int argc, char** argv) {
   }
   spdlog::debug("log level={}", config.log_level);
 
-  std::ifstream i(config.in_metadata_filename);
-  if (!i.is_open()) {
-    spdlog::error("failed to open metadata json file: {}",
-                  config.in_metadata_filename);
-    return 1;
-  }
-  std::string string_json((std::istreambuf_iterator<char>(i)),
-                          std::istreambuf_iterator<char>());
-  boost::json::error_code ec;
-  boost::json::value jv = boost::json::parse(string_json, ec);
-  if (ec) {
-    spdlog::error("failed to parse metadata json file: message", ec.message());
-    return 1;
-  }
-
-  const hisui::Metadata metadata =
-      hisui::parse_metadata(config.in_metadata_filename, jv);
-
   if (!config.openh264.empty()) {
     try {
       hisui::video::OpenH264Handler::open(config.openh264);
@@ -70,14 +47,22 @@ int main(int argc, char** argv) {
     }
   }
 
+  hisui::MetadataSet metadata_set(
+      hisui::parse_metadata(config.in_metadata_filename));
+
+  if (config.screen_capture_metadata_filename != "") {
+    metadata_set.setPrefered(
+        hisui::parse_metadata(config.screen_capture_metadata_filename));
+  }
+
   hisui::muxer::Muxer* muxer = nullptr;
   if (config.out_container == hisui::config::OutContainer::WebM) {
-    muxer = new hisui::muxer::AsyncWebMMuxer(config, metadata);
+    muxer = new hisui::muxer::AsyncWebMMuxer(config, metadata_set);
   } else if (config.out_container == hisui::config::OutContainer::MP4) {
     if (config.mp4_muxer == hisui::config::MP4Muxer::Simple) {
-      muxer = new hisui::muxer::SimpleMP4Muxer(config, metadata);
+      muxer = new hisui::muxer::SimpleMP4Muxer(config, metadata_set);
     } else if (config.mp4_muxer == hisui::config::MP4Muxer::Faststart) {
-      muxer = new hisui::muxer::FaststartMP4Muxer(config, metadata);
+      muxer = new hisui::muxer::FaststartMP4Muxer(config, metadata_set);
     } else {
       throw std::runtime_error("config.mp4_muxer is invalid");
     }

--- a/src/hisui.cpp
+++ b/src/hisui.cpp
@@ -46,9 +46,11 @@ int main(int argc, char** argv) {
   hisui::MetadataSet metadata_set(
       hisui::parse_metadata(config.in_metadata_filename));
 
-  if (config.screen_capture_metadata_filename != "") {
+  if (!config.screen_capture_metadata_filename.empty()) {
     metadata_set.setPrefered(
         hisui::parse_metadata(config.screen_capture_metadata_filename));
+  } else if (!config.screen_capture_connection_id.empty()) {
+    metadata_set.split(config.screen_capture_connection_id);
   }
 
   hisui::muxer::Muxer* muxer = nullptr;

--- a/src/hisui.cpp
+++ b/src/hisui.cpp
@@ -26,11 +26,7 @@ int main(int argc, char** argv) {
 
   CLI11_PARSE(app, argc, argv);
 
-  if (config.out_container == hisui::config::OutContainer::WebM &&
-      config.out_audio_codec == hisui::config::OutAudioCodec::FDK_AAC) {
-    spdlog::error("hisui does not support AAC output in WebM");
-    return 1;
-  }
+  config.validate();
 
   if (config.verbose) {
     spdlog::set_level(spdlog::level::debug);

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,17 +1,21 @@
 #include "metadata.hpp"
 
 #include <bits/exception.h>
-#include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/bundled/format.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <compare>
 #include <filesystem>
-#include <map>
+#include <fstream>
+#include <iterator>
 #include <stdexcept>
 #include <tuple>
 #include <utility>
 
-#include <boost/json.hpp>
+#include <boost/json/impl/array.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/system_error.hpp>
 
 namespace hisui {
 
@@ -40,8 +44,22 @@ double Archive::getStopTimeOffset() const {
   return m_stop_time_offset;
 }
 
-Metadata::Metadata(const std::string& file_path,
-                   const boost::json::array& json_archives)
+void Archive::adjustTimeOffsets(double diff) {
+  m_start_time_offset += diff;
+  m_stop_time_offset += diff;
+}
+
+Archive& Archive::operator=(const Archive& other) {
+  if (this != &other) {
+    this->m_path = other.m_path;
+    this->m_connection_id = other.m_connection_id;
+    this->m_start_time_offset = other.m_start_time_offset;
+    this->m_stop_time_offset = other.m_stop_time_offset;
+  }
+  return *this;
+}
+
+Metadata::Metadata(const std::string& file_path, const boost::json::value& jv)
     : m_path(file_path) {
   if (m_path.is_relative()) {
     m_path = std::filesystem::absolute(m_path);
@@ -49,6 +67,9 @@ Metadata::Metadata(const std::string& file_path,
   const auto current_path = std::filesystem::current_path();
   std::filesystem::current_path(m_path.parent_path());
   std::vector<std::tuple<std::string, std::string, double, double>> archives;
+
+  auto json_archives = prepare(jv);
+
   for (const auto& a : json_archives) {
     boost::json::object o;
     if (auto p = a.if_object()) {
@@ -56,40 +77,12 @@ Metadata::Metadata(const std::string& file_path,
     } else {
       throw std::runtime_error("a.if_object() failed");
     }
-    boost::json::string a_file_path;
-    if (auto p = o["file_path"].if_string()) {
-      a_file_path = *p;
-    } else {
-      throw std::runtime_error("file_path.if_object() failed");
-    }
-    boost::json::string a_connection_id;
-    if (auto p = o["connection_id"].if_string()) {
-      a_connection_id = *p;
-    } else {
-      throw std::runtime_error("connection_id.if_object() failed");
-    }
-    double a_start_time_offset;
-    if (o["start_time_offset"].is_number()) {
-      boost::json::error_code ec;
-      a_start_time_offset = o["start_time_offset"].to_number<double>(ec);
-      if (ec) {
-        throw std::runtime_error("start_time_offset.to_number() failed: " +
-                                 ec.message());
-      }
-    } else {
-      throw std::runtime_error("start_time_offset is not number");
-    }
-    double a_stop_time_offset;
-    if (o["stop_time_offset"].is_number()) {
-      boost::json::error_code ec;
-      a_stop_time_offset = o["stop_time_offset"].to_number<double>(ec);
-      if (ec) {
-        throw std::runtime_error("stop_time_offset.to_number() failed: " +
-                                 ec.message());
-      }
-    } else {
-      throw std::runtime_error("stop_time_offset is not number");
-    }
+    auto a_file_path = get_string_from_json_object(o, "file_path");
+    auto a_connection_id = get_string_from_json_object(o, "connection_id");
+    double a_start_time_offset =
+        get_double_from_json_object(o, "start_time_offset");
+    double a_stop_time_offset =
+        get_double_from_json_object(o, "stop_time_offset");
     spdlog::debug("{} {} {} {}", a_file_path, a_connection_id,
                   a_start_time_offset, a_stop_time_offset);
     archives.emplace_back(a_file_path, a_connection_id, a_start_time_offset,
@@ -132,14 +125,25 @@ Metadata::Metadata(const std::string& file_path,
     }
     Archive archive(path, get<1>(a), get<2>(a), get<3>(a));
     m_archives.push_back(archive);
-    if (get<2>(a) < m_min_start_time_offset) {
-      m_min_start_time_offset = get<2>(a);
+  }
+  setTimeOffsets();
+  std::filesystem::current_path(current_path);
+}
+
+Metadata::Metadata(const std::vector<Archive>& t_archives)
+    : m_archives(t_archives) {
+  setTimeOffsets();
+}
+
+void Metadata::setTimeOffsets() {
+  for (const auto& archive : m_archives) {
+    if (archive.getStartTimeOffset() < m_min_start_time_offset) {
+      m_min_start_time_offset = archive.getStartTimeOffset();
     }
-    if (get<3>(a) > m_max_stop_time_offset) {
-      m_max_stop_time_offset = get<3>(a);
+    if (archive.getStopTimeOffset() > m_max_stop_time_offset) {
+      m_max_stop_time_offset = archive.getStopTimeOffset();
     }
   }
-  std::filesystem::current_path(current_path);
 }
 
 std::vector<Archive> Metadata::getArchives() const {
@@ -154,14 +158,20 @@ double Metadata::getMaxStopTimeOffset() const {
   return m_max_stop_time_offset;
 }
 
-Metadata parse_metadata(const std::string& filename,
-                        const boost::json::value& jv) {
+double Metadata::getCreatedAt() const {
+  return m_created_at;
+}
+
+boost::json::array Metadata::prepare(const boost::json::value& jv) {
   boost::json::object j;
   if (auto p = jv.if_object()) {
     j = *p;
   } else {
     throw std::runtime_error("jv.if_object() failed");
   }
+
+  m_recording_id = get_string_from_json_object(j, "recording_id");
+  m_created_at = get_double_from_json_object(j, "created_at");
 
   if (j["archives"] == nullptr) {
     throw std::invalid_argument("not metadata json file: {}");
@@ -177,8 +187,25 @@ Metadata parse_metadata(const std::string& filename,
   if (std::size(ja) == 0) {
     throw std::invalid_argument("metadata json file does not include archives");
   }
+  return ja;
+}
 
-  Metadata metadata(filename, ja);
+Metadata parse_metadata(const std::string& filename) {
+  std::ifstream i(filename);
+  if (!i.is_open()) {
+    throw std::runtime_error(
+        fmt::format("failed to open metadata json file: {}", filename));
+  }
+  std::string string_json((std::istreambuf_iterator<char>(i)),
+                          std::istreambuf_iterator<char>());
+  boost::json::error_code ec;
+  boost::json::value jv = boost::json::parse(string_json, ec);
+  if (ec) {
+    throw std::runtime_error(fmt::format(
+        "failed to parse metadata json file: message", ec.message()));
+  }
+
+  Metadata metadata(filename, jv);
 
   spdlog::debug("metadata min_start_time_offset={}",
                 metadata.getMinStartTimeOffset());
@@ -188,10 +215,93 @@ Metadata parse_metadata(const std::string& filename,
     spdlog::debug("  file_path='{} start_time_offset={} stop_time_offset={}",
                   archive.getPath().string(), archive.getStartTimeOffset(),
                   archive.getStopTimeOffset());
-    metadata.getMaxStopTimeOffset();
   }
 
   return metadata;
+}
+
+void Metadata::adjustTimeOffsets(double diff) {
+  m_min_start_time_offset += diff;
+  m_max_stop_time_offset += diff;
+  for (auto& archive : m_archives) {
+    archive.adjustTimeOffsets(diff);
+  }
+}
+
+MetadataSet::MetadataSet(const Metadata& t_normal)
+    : m_normal(t_normal), m_preferred({}) {}
+
+void MetadataSet::setPrefered(const Metadata& t_preferred) {
+  m_has_preferred = true;
+  m_preferred = t_preferred;
+  auto diff = m_normal.getCreatedAt() - m_preferred.getCreatedAt();
+  if (diff > 0) {
+    m_normal.adjustTimeOffsets(diff);
+  } else {
+    m_preferred.adjustTimeOffsets(diff);
+  }
+}
+
+std::vector<Archive> MetadataSet::getArchives() const {
+  if (m_has_preferred) {
+    std::vector<hisui::Archive> archives;
+    auto a0 = m_normal.getArchives();
+    archives.insert(std::end(archives), std::begin(a0), std::end(a0));
+    auto a1 = m_preferred.getArchives();
+    archives.insert(std::end(archives), std::begin(a1), std::end(a1));
+    return archives;
+  }
+  return m_normal.getArchives();
+}
+
+std::vector<Archive> MetadataSet::getNormalArchives() const {
+  return m_normal.getArchives();
+}
+
+Metadata MetadataSet::getNormal() const {
+  return m_normal;
+}
+
+Metadata MetadataSet::getPreferred() const {
+  return m_preferred;
+}
+
+bool MetadataSet::hasPreferred() const {
+  return m_has_preferred;
+}
+
+double MetadataSet::getMaxStopTimeOffset() const {
+  if (m_has_preferred) {
+    return std::max(m_normal.getMaxStopTimeOffset(),
+                    m_preferred.getMaxStopTimeOffset());
+  }
+  return m_normal.getMaxStopTimeOffset();
+}
+
+boost::json::string Metadata::getRecordingID() const {
+  return m_recording_id;
+}
+
+boost::json::string get_string_from_json_object(boost::json::object o,
+                                                const std::string& key) {
+  if (auto p = o[key].if_string()) {
+    return *p;
+  }
+  throw std::runtime_error(fmt::format("o[{}].if_string() failed", key));
+}
+
+double get_double_from_json_object(boost::json::object o,
+                                   const std::string& key) {
+  if (o[key].is_number()) {
+    boost::json::error_code ec;
+    auto value = o[key].to_number<double>(ec);
+    if (ec) {
+      throw std::runtime_error(
+          fmt::format("o[{}].to_number() failed: {}", key, ec.message()));
+    }
+    return value;
+  }
+  throw std::runtime_error("start_time_offset is not number");
 }
 
 }  // namespace hisui

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -5,7 +5,7 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
-#include <compare>
+#include <compare>  // NOLINT
 #include <filesystem>
 #include <fstream>
 #include <iterator>

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -238,7 +238,7 @@ void MetadataSet::setPrefered(const Metadata& t_preferred) {
   if (diff > 0) {
     m_normal.adjustTimeOffsets(diff);
   } else {
-    m_preferred.adjustTimeOffsets(diff);
+    m_preferred.adjustTimeOffsets(-diff);
   }
 }
 

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -38,13 +38,18 @@ class Metadata {
  public:
   Metadata(const std::string&, const boost::json::value&);
   explicit Metadata(const std::vector<Archive>&);
+
   std::vector<Archive> getArchives() const;
   double getMinStartTimeOffset() const;
   double getMaxStopTimeOffset() const;
   double getCreatedAt() const;
-  void adjustTimeOffsets(double);
   std::filesystem::path getPath() const;
   boost::json::string getRecordingID() const;
+
+  void adjustTimeOffsets(double);
+  void copyWithoutArchives(const Metadata&);
+  void setArchives(const std::vector<Archive>&);
+  std::vector<Archive> deleteArchivesByConnectionID(const std::string&);
 
  private:
   void setTimeOffsets();
@@ -64,6 +69,7 @@ class MetadataSet {
  public:
   explicit MetadataSet(const Metadata&);
   void setPrefered(const Metadata&);
+  void split(const std::string&);
   Metadata getNormal() const;
   Metadata getPreferred() const;
   bool hasPreferred() const;

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -5,7 +5,10 @@
 #include <string>
 #include <vector>
 
-#include <boost/json.hpp>
+#include <boost/json/array.hpp>
+#include <boost/json/object.hpp>
+#include <boost/json/string.hpp>
+#include <boost/json/value.hpp>
 
 namespace hisui {
 
@@ -20,30 +23,63 @@ class Archive {
   std::string getConnectionID() const;
   double getStartTimeOffset() const;
   double getStopTimeOffset() const;
+  void adjustTimeOffsets(double);
+
+  Archive& operator=(const Archive& other);
 
  private:
-  const std::filesystem::path m_path;
-  const std::string m_connection_id;
-  const double m_start_time_offset;
-  const double m_stop_time_offset;
+  std::filesystem::path m_path;
+  std::string m_connection_id;
+  double m_start_time_offset;
+  double m_stop_time_offset;
 };
 
 class Metadata {
  public:
-  Metadata(const std::string&, const boost::json::array&);
+  Metadata(const std::string&, const boost::json::value&);
+  explicit Metadata(const std::vector<Archive>&);
   std::vector<Archive> getArchives() const;
   double getMinStartTimeOffset() const;
   double getMaxStopTimeOffset() const;
+  double getCreatedAt() const;
+  void adjustTimeOffsets(double);
   std::filesystem::path getPath() const;
+  boost::json::string getRecordingID() const;
 
  private:
-  std::filesystem::path m_path;
+  void setTimeOffsets();
+  boost::json::array prepare(const boost::json::value& jv);
 
+  std::filesystem::path m_path;
   std::vector<Archive> m_archives;
   double m_min_start_time_offset = std::numeric_limits<double>::max();
   double m_max_stop_time_offset = std::numeric_limits<double>::min();
+  double m_created_at;
+  boost::json::string m_recording_id;
 };
 
+Metadata parse_metadata(const std::string&);
+
+class MetadataSet {
+ public:
+  explicit MetadataSet(const Metadata&);
+  void setPrefered(const Metadata&);
+  Metadata getNormal() const;
+  Metadata getPreferred() const;
+  bool hasPreferred() const;
+  std::vector<Archive> getArchives() const;
+  std::vector<Archive> getNormalArchives() const;
+  double getMaxStopTimeOffset() const;
+
+ private:
+  Metadata m_normal;
+  Metadata m_preferred;
+  bool m_has_preferred = false;
+};
 Metadata parse_metadata(const std::string&, const boost::json::value&);
+boost::json::string get_string_from_json_object(boost::json::object o,
+                                                const std::string& key);
+double get_double_from_json_object(boost::json::object o,
+                                   const std::string& key);
 
 }  // namespace hisui

--- a/src/muxer/async_webm_muxer.cpp
+++ b/src/muxer/async_webm_muxer.cpp
@@ -11,6 +11,7 @@
 #include "constants.hpp"
 #include "frame.hpp"
 #include "muxer/audio_producer.hpp"
+#include "muxer/multi_channel_vpx_video_producer.hpp"
 #include "muxer/no_video_producer.hpp"
 #include "muxer/opus_audio_producer.hpp"
 #include "muxer/video_producer.hpp"
@@ -20,8 +21,8 @@
 namespace hisui::muxer {
 
 AsyncWebMMuxer::AsyncWebMMuxer(const hisui::Config& t_config,
-                               const hisui::Metadata& t_metadata)
-    : m_config(t_config), m_metadata(t_metadata) {}
+                               const hisui::MetadataSet& t_metadata_set)
+    : m_config(t_config), m_metadata_set(t_metadata_set) {}
 
 void AsyncWebMMuxer::setUp() {
   if (m_config.out_filename == "") {
@@ -44,18 +45,26 @@ void AsyncWebMMuxer::setUp() {
   } else {
     if (m_config.out_video_bit_rate == 0) {
       m_config.out_video_bit_rate =
-          static_cast<std::uint32_t>(std::size(m_metadata.getArchives())) *
+          static_cast<std::uint32_t>(
+              std::size(m_metadata_set.getNormalArchives())) *
           hisui::Constants::VIDEO_VPX_BIT_RATE_PER_FILE;
     }
 
-    m_video_producer = new VPXVideoProducer(m_config, m_metadata);
+    if (m_metadata_set.hasPreferred()) {
+      m_video_producer =
+          new MultiChannelVPXVideoProducer(m_config, m_metadata_set);
+    } else {
+      m_video_producer =
+          new VPXVideoProducer(m_config, m_metadata_set.getNormal());
+    }
+
     m_context->setVideoTrack(m_video_producer->getWidth(),
                              m_video_producer->getHeight(),
                              m_video_producer->getFourcc());
   }
 
   OpusAudioProducer* audio_producer =
-      new OpusAudioProducer(m_config, m_metadata);
+      new OpusAudioProducer(m_config, m_metadata_set);
   const auto skip = audio_producer->getSkip();
   m_audio_producer = audio_producer;
 

--- a/src/muxer/async_webm_muxer.hpp
+++ b/src/muxer/async_webm_muxer.hpp
@@ -22,7 +22,7 @@ namespace hisui::muxer {
 
 class AsyncWebMMuxer : public Muxer {
  public:
-  AsyncWebMMuxer(const hisui::Config&, const hisui::Metadata&);
+  AsyncWebMMuxer(const hisui::Config&, const hisui::MetadataSet&);
   ~AsyncWebMMuxer();
 
   void setUp() override;
@@ -38,7 +38,7 @@ class AsyncWebMMuxer : public Muxer {
   std::FILE* m_file;
 
   hisui::Config m_config;
-  hisui::Metadata m_metadata;
+  hisui::MetadataSet m_metadata_set;
 };
 
 }  // namespace hisui::muxer

--- a/src/muxer/audio_producer.cpp
+++ b/src/muxer/audio_producer.cpp
@@ -1,6 +1,7 @@
 #include "muxer/audio_producer.hpp"
 
 #include <bits/exception.h>
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include <cmath>
@@ -14,6 +15,7 @@
 #include "audio/encoder.hpp"
 #include "audio/sequencer.hpp"
 #include "constants.hpp"
+#include "frame.hpp"
 
 namespace hisui::muxer {
 

--- a/src/muxer/audio_producer.hpp
+++ b/src/muxer/audio_producer.hpp
@@ -5,7 +5,11 @@
 #include <optional>
 #include <queue>
 
-#include "frame.hpp"
+namespace hisui {
+
+struct Frame;
+
+}
 
 namespace hisui::audio {
 

--- a/src/muxer/faststart_mp4_muxer.cpp
+++ b/src/muxer/faststart_mp4_muxer.cpp
@@ -1,6 +1,8 @@
 #include "muxer/faststart_mp4_muxer.hpp"
 
 #include <bits/exception.h>
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
@@ -23,8 +25,8 @@ class Track;
 namespace hisui::muxer {
 
 FaststartMP4Muxer::FaststartMP4Muxer(const hisui::Config& t_config,
-                                     const hisui::Metadata& t_metadata)
-    : m_config(t_config), m_metadata(t_metadata) {}
+                                     const hisui::MetadataSet& t_metadata_set)
+    : m_config(t_config), m_metadata_set(t_metadata_set) {}
 
 void FaststartMP4Muxer::setUp() {
   std::filesystem::path directory_for_faststart_intermediate_file;
@@ -47,14 +49,15 @@ void FaststartMP4Muxer::setUp() {
   spdlog::debug("directory_for_faststart_intermediate_file: {}",
                 directory_for_faststart_intermediate_file.string());
 
-  const float duration = static_cast<float>(m_metadata.getMaxStopTimeOffset());
+  const float duration =
+      static_cast<float>(m_metadata_set.getMaxStopTimeOffset());
   m_faststart_writer = new shiguredo::mp4::writer::FaststartWriter(
       m_ofs, {.mvhd_timescale = 1000,
               .duration = duration,
               .mdat_path_templete =
                   directory_for_faststart_intermediate_file.string() +
                   std::filesystem::path::preferred_separator + "mdatXXXXXX"});
-  initialize(m_config, m_metadata, m_faststart_writer, duration);
+  initialize(m_config, m_metadata_set, m_faststart_writer, duration);
 }
 
 FaststartMP4Muxer::~FaststartMP4Muxer() {

--- a/src/muxer/faststart_mp4_muxer.hpp
+++ b/src/muxer/faststart_mp4_muxer.hpp
@@ -14,7 +14,7 @@ namespace hisui::muxer {
 
 class FaststartMP4Muxer : public MP4Muxer {
  public:
-  FaststartMP4Muxer(const hisui::Config&, const hisui::Metadata&);
+  FaststartMP4Muxer(const hisui::Config&, const hisui::MetadataSet&);
   ~FaststartMP4Muxer();
 
   void setUp() override;
@@ -25,7 +25,7 @@ class FaststartMP4Muxer : public MP4Muxer {
   shiguredo::mp4::writer::FaststartWriter* m_faststart_writer;
 
   hisui::Config m_config;
-  hisui::Metadata m_metadata;
+  hisui::MetadataSet m_metadata_set;
 };
 
 }  // namespace hisui::muxer

--- a/src/muxer/fdk_aac_audio_producer.cpp
+++ b/src/muxer/fdk_aac_audio_producer.cpp
@@ -8,8 +8,9 @@
 
 namespace hisui::muxer {
 
-FDKAACAudioProducer::FDKAACAudioProducer(const hisui::Config& t_config,
-                                         const hisui::Metadata& t_metadata)
+FDKAACAudioProducer::FDKAACAudioProducer(
+    const hisui::Config& t_config,
+    const hisui::MetadataSet& t_metadata_set)
     : AudioProducer({.show_progress_bar =
                          t_config.show_progress_bar && t_config.audio_only}) {
   switch (t_config.audio_mixer) {
@@ -21,8 +22,8 @@ FDKAACAudioProducer::FDKAACAudioProducer(const hisui::Config& t_config,
       break;
   }
 
-  m_sequencer = new hisui::audio::BasicSequencer(t_metadata.getArchives());
-  m_max_stop_time_offset = t_metadata.getMaxStopTimeOffset();
+  m_sequencer = new hisui::audio::BasicSequencer(t_metadata_set.getArchives());
+  m_max_stop_time_offset = t_metadata_set.getMaxStopTimeOffset();
 
   m_encoder = new hisui::audio::BufferFDKAACEncoder(
       &m_buffer, {.bit_rate = t_config.out_aac_bit_rate});

--- a/src/muxer/fdk_aac_audio_producer.hpp
+++ b/src/muxer/fdk_aac_audio_producer.hpp
@@ -5,7 +5,7 @@
 namespace hisui {
 
 class Config;
-class Metadata;
+class MetadataSet;
 
 }  // namespace hisui
 
@@ -13,7 +13,7 @@ namespace hisui::muxer {
 
 class FDKAACAudioProducer : public AudioProducer {
  public:
-  FDKAACAudioProducer(const hisui::Config&, const hisui::Metadata& i);
+  FDKAACAudioProducer(const hisui::Config&, const hisui::MetadataSet&);
 };
 
 }  // namespace hisui::muxer

--- a/src/muxer/mp4_muxer.cpp
+++ b/src/muxer/mp4_muxer.cpp
@@ -6,12 +6,14 @@
 #include <string>
 #include <vector>
 
+#include <boost/cstdint.hpp>
 #include <boost/rational.hpp>
 
 #include "config.hpp"
 #include "constants.hpp"
 #include "metadata.hpp"
 #include "muxer/audio_producer.hpp"
+#include "muxer/multi_channel_vpx_video_producer.hpp"
 #include "muxer/no_video_producer.hpp"
 #include "muxer/opus_audio_producer.hpp"
 #include "muxer/video_producer.hpp"
@@ -30,15 +32,15 @@
 namespace hisui::muxer {
 
 void MP4Muxer::initialize(const hisui::Config& config_orig,
-                          const hisui::Metadata& metadata,
+                          const hisui::MetadataSet& metadata_set,
                           shiguredo::mp4::writer::Writer* writer,
                           const float duration) {
   m_writer = writer;
   hisui::Config config = config_orig;
   if (config.out_video_bit_rate == 0) {
-    config.out_video_bit_rate =
-        static_cast<std::uint32_t>(std::size(metadata.getArchives())) *
-        hisui::Constants::VIDEO_VPX_BIT_RATE_PER_FILE;
+    config.out_video_bit_rate = static_cast<std::uint32_t>(std::size(
+                                    metadata_set.getNormalArchives())) *
+                                hisui::Constants::VIDEO_VPX_BIT_RATE_PER_FILE;
   } else {
     config.out_video_bit_rate = config.out_video_bit_rate;
   }
@@ -62,7 +64,7 @@ void MP4Muxer::initialize(const hisui::Config& config_orig,
 
   if (config.out_audio_codec == config::OutAudioCodec::FDK_AAC) {
 #ifdef USE_FDK_AAC
-    m_audio_producer = new FDKAACAudioProducer(config, metadata);
+    m_audio_producer = new FDKAACAudioProducer(config, metadata_set);
     m_soun_track = new shiguredo::mp4::track::AACTrack({
         .timescale = 48000,
         .duration = duration,
@@ -76,7 +78,7 @@ void MP4Muxer::initialize(const hisui::Config& config_orig,
 #endif
   } else {
     OpusAudioProducer* audio_producer =
-        new OpusAudioProducer(config, metadata, 48000);
+        new OpusAudioProducer(config, metadata_set, 48000);
     const auto skip = audio_producer->getSkip();
     m_audio_producer = audio_producer;
     m_soun_track = new shiguredo::mp4::track::OpusTrack(
@@ -90,7 +92,13 @@ void MP4Muxer::initialize(const hisui::Config& config_orig,
     m_video_producer = new NoVideoProducer();
     m_timescale_ratio.assign(1, 1);
   } else {
-    m_video_producer = new VPXVideoProducer(config, metadata, 16000);
+    if (metadata_set.hasPreferred()) {
+      m_video_producer =
+          new MultiChannelVPXVideoProducer(config, metadata_set, 16000);
+    } else {
+      m_video_producer =
+          new VPXVideoProducer(config, metadata_set.getNormal(), 16000);
+    }
     m_vide_track = new shiguredo::mp4::track::VPXTrack(
         {.timescale = 16000,
          .duration = duration,

--- a/src/muxer/mp4_muxer.hpp
+++ b/src/muxer/mp4_muxer.hpp
@@ -10,7 +10,7 @@
 namespace hisui {
 
 class Config;
-class Metadata;
+class MetadataSet;
 
 }  // namespace hisui
 
@@ -49,10 +49,10 @@ class MP4Muxer : public Muxer {
   void appendVideo(hisui::Frame) override;
 
   void writeTrackData();
-  void initialize(const hisui::Config& t_config,
-                  const hisui::Metadata& t_metadata,
-                  shiguredo::mp4::writer::Writer* writer,
-                  const float duration);
+  void initialize(const hisui::Config&,
+                  const hisui::MetadataSet&,
+                  shiguredo::mp4::writer::Writer*,
+                  const float);
 };
 
 }  // namespace hisui::muxer

--- a/src/muxer/multi_channel_vpx_video_producer.cpp
+++ b/src/muxer/multi_channel_vpx_video_producer.cpp
@@ -1,0 +1,168 @@
+#include "muxer/multi_channel_vpx_video_producer.hpp"
+
+#include <bits/exception.h>
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include <boost/rational.hpp>
+#include <progresscpp/ProgressBar.hpp>
+
+#include "config.hpp"
+#include "metadata.hpp"
+#include "muxer/video_producer.hpp"
+#include "video/buffer_vpx_encoder.hpp"
+#include "video/composer.hpp"
+#include "video/encoder.hpp"
+#include "video/grid_composer.hpp"
+#include "video/multi_channel_sequencer.hpp"
+#include "video/parallel_grid_composer.hpp"
+#include "video/sequencer.hpp"
+#include "video/vpx.hpp"
+
+namespace hisui::video {
+
+class YUVImage;
+
+}
+
+namespace hisui::muxer {
+
+MultiChannelVPXVideoProducer::MultiChannelVPXVideoProducer(
+    const hisui::Config& t_config,
+    const hisui::MetadataSet& t_metadata_set,
+    const std::uint64_t timescale)
+    : VideoProducer({.show_progress_bar = t_config.show_progress_bar}),
+      m_normal_bit_rate(t_config.out_video_bit_rate),
+      m_preferred_bit_rate(t_config.screen_capture_bit_rate) {
+  m_sequencer = new hisui::video::MultiChannelSequencer(
+      t_metadata_set.getNormal().getArchives(),
+      t_metadata_set.getPreferred().getArchives());
+
+  const auto scaling_width = t_config.scaling_width != 0
+                                 ? t_config.scaling_width
+                                 : m_sequencer->getMaxWidth();
+  const auto scaling_height = t_config.scaling_height != 0
+                                  ? t_config.scaling_height
+                                  : m_sequencer->getMaxHeight();
+
+  switch (t_config.video_composer) {
+    case hisui::config::VideoComposer::Grid:
+      m_normal_channel_composer = new hisui::video::GridComposer(
+          scaling_width, scaling_height, m_sequencer->getSize(),
+          t_config.max_columns, t_config.video_scaler,
+          t_config.libyuv_filter_mode);
+      m_preferred_channel_composer = new hisui::video::GridComposer(
+          t_config.screen_capture_width, t_config.screen_capture_height, 1, 1,
+          t_config.video_scaler, t_config.libyuv_filter_mode);
+      break;
+    case hisui::config::VideoComposer::ParallelGrid:
+      m_normal_channel_composer = new hisui::video::ParallelGridComposer(
+          scaling_width, scaling_height, m_sequencer->getSize(),
+          t_config.max_columns, t_config.video_scaler,
+          t_config.libyuv_filter_mode);
+      m_preferred_channel_composer = new hisui::video::GridComposer(
+          t_config.screen_capture_width, t_config.screen_capture_height, 1, 1,
+          t_config.video_scaler, t_config.libyuv_filter_mode);
+      break;
+  }
+
+  m_composer = m_normal_channel_composer;
+
+  hisui::video::VPXEncoderConfig vpx_config(
+      std::max(m_normal_channel_composer->getWidth(),
+               m_preferred_channel_composer->getWidth()),
+      std::max(m_normal_channel_composer->getHeight(),
+               m_preferred_channel_composer->getHeight()),
+      t_config);
+
+  m_encoder =
+      new hisui::video::BufferVPXEncoder(&m_buffer, vpx_config, timescale);
+
+  m_max_stop_time_offset = t_metadata_set.getMaxStopTimeOffset();
+  m_frame_rate = t_config.out_video_frame_rate;
+}
+
+MultiChannelVPXVideoProducer::~MultiChannelVPXVideoProducer() {
+  delete m_normal_channel_composer;
+  m_normal_channel_composer = nullptr;
+  delete m_preferred_channel_composer;
+  m_preferred_channel_composer = nullptr;
+  m_composer = nullptr;
+}
+
+void MultiChannelVPXVideoProducer::produce() {
+  if (isFinished()) {
+    return;
+  }
+
+  try {
+    std::vector<const video::YUVImage*> yuvs;
+    std::vector<unsigned char> raw_image;
+    yuvs.resize(m_sequencer->getSize());
+
+    const std::uint64_t max_time = static_cast<std::uint64_t>(
+        std::ceil(m_max_stop_time_offset * hisui::Constants::NANO_SECOND));
+
+    progresscpp::ProgressBar progress_bar(max_time, 60);
+
+    for (std::uint64_t t = 0, step = hisui::Constants::NANO_SECOND *
+                                     m_frame_rate.denominator() /
+                                     m_frame_rate.numerator();
+         t < max_time; t += step) {
+      auto result = m_sequencer->getYUVs(&yuvs, t);
+      if (result.is_preferred_stream) {
+        raw_image.resize(m_preferred_channel_composer->getWidth() *
+                             m_preferred_channel_composer->getHeight() * 3 >>
+                         1);
+        m_preferred_channel_composer->compose(&raw_image, {yuvs[0]});
+        m_encoder->setResolutionAndBitrate(
+            m_preferred_channel_composer->getWidth(),
+            m_preferred_channel_composer->getHeight(), m_preferred_bit_rate);
+        {
+          std::lock_guard<std::mutex> lock(m_mutex_buffer);
+          m_encoder->outputImage(raw_image);
+        }
+
+      } else {
+        raw_image.resize(m_normal_channel_composer->getWidth() *
+                             m_normal_channel_composer->getHeight() * 3 >>
+                         1);
+        m_normal_channel_composer->compose(&raw_image, yuvs);
+        m_encoder->setResolutionAndBitrate(
+            m_normal_channel_composer->getWidth(),
+            m_normal_channel_composer->getHeight(), m_normal_bit_rate);
+        {
+          std::lock_guard<std::mutex> lock(m_mutex_buffer);
+          m_encoder->outputImage(raw_image);
+        }
+      }
+      if (m_show_progress_bar) {
+        progress_bar.setTicks(t);
+        progress_bar.display();
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(m_mutex_buffer);
+      m_encoder->flush();
+      m_is_finished = true;
+    }
+
+    if (m_show_progress_bar) {
+      progress_bar.setTicks(max_time);
+      progress_bar.done();
+    }
+  } catch (const std::exception& e) {
+    spdlog::error("VideoProducer::produce() failed: what={}", e.what());
+    m_is_finished = true;
+    throw e;
+  }
+}
+
+}  // namespace hisui::muxer

--- a/src/muxer/multi_channel_vpx_video_producer.hpp
+++ b/src/muxer/multi_channel_vpx_video_producer.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+#include "constants.hpp"
+#include "muxer/video_producer.hpp"
+
+namespace hisui {
+
+class Config;
+class MetadataSet;
+
+}  // namespace hisui
+
+namespace hisui::video {
+
+class Composer;
+
+}
+
+namespace hisui::muxer {
+
+class MultiChannelVPXVideoProducer : public VideoProducer {
+ public:
+  MultiChannelVPXVideoProducer(
+      const hisui::Config&,
+      const hisui::MetadataSet&,
+      const std::uint64_t timescale = hisui::Constants::NANO_SECOND);
+  ~MultiChannelVPXVideoProducer();
+  void produce() override;
+
+ private:
+  hisui::video::Composer* m_normal_channel_composer = nullptr;
+  hisui::video::Composer* m_preferred_channel_composer = nullptr;
+
+  const std::uint32_t m_normal_bit_rate;
+  const std::uint32_t m_preferred_bit_rate;
+};
+
+}  // namespace hisui::muxer

--- a/src/muxer/muxer.cpp
+++ b/src/muxer/muxer.cpp
@@ -9,6 +9,7 @@
 #include <system_error>
 #include <thread>
 
+#include <boost/cstdint.hpp>
 #include <boost/exception/exception.hpp>
 #include <boost/rational.hpp>
 

--- a/src/muxer/muxer.hpp
+++ b/src/muxer/muxer.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include <boost/cstdint.hpp>
 #include <boost/rational.hpp>
 
 namespace hisui {

--- a/src/muxer/opus_audio_producer.cpp
+++ b/src/muxer/opus_audio_producer.cpp
@@ -12,7 +12,7 @@
 namespace hisui::muxer {
 
 OpusAudioProducer::OpusAudioProducer(const hisui::Config& t_config,
-                                     const hisui::Metadata& t_metadata,
+                                     const hisui::MetadataSet& t_metadata_set,
                                      const std::uint64_t timescale)
     : AudioProducer({.show_progress_bar =
                          t_config.show_progress_bar && t_config.audio_only}) {
@@ -25,8 +25,9 @@ OpusAudioProducer::OpusAudioProducer(const hisui::Config& t_config,
       break;
   }
 
-  m_sequencer = new hisui::audio::BasicSequencer(t_metadata.getArchives());
-  m_max_stop_time_offset = t_metadata.getMaxStopTimeOffset();
+  m_sequencer = new hisui::audio::BasicSequencer(t_metadata_set.getArchives());
+
+  m_max_stop_time_offset = t_metadata_set.getMaxStopTimeOffset();
 
   hisui::audio::BufferOpusEncoder* encoder =
       new hisui::audio::BufferOpusEncoder(

--- a/src/muxer/opus_audio_producer.hpp
+++ b/src/muxer/opus_audio_producer.hpp
@@ -10,7 +10,7 @@
 namespace hisui {
 
 class Config;
-class Metadata;
+class MetadataSet;
 
 }  // namespace hisui
 
@@ -20,7 +20,7 @@ class OpusAudioProducer : public AudioProducer {
  public:
   OpusAudioProducer(
       const hisui::Config&,
-      const hisui::Metadata& i,
+      const hisui::MetadataSet&,
       const std::uint64_t timescale = hisui::Constants::NANO_SECOND);
   ::opus_int32 getSkip() const;
 

--- a/src/muxer/simple_mp4_muxer.cpp
+++ b/src/muxer/simple_mp4_muxer.cpp
@@ -16,14 +16,15 @@ class Track;
 namespace hisui::muxer {
 
 SimpleMP4Muxer::SimpleMP4Muxer(const hisui::Config& t_config,
-                               const hisui::Metadata& t_metadata)
-    : m_config(t_config), m_metadata(t_metadata) {}
+                               const hisui::MetadataSet& t_metadata_set)
+    : m_config(t_config), m_metadata_set(t_metadata_set) {}
 
 void SimpleMP4Muxer::setUp() {
-  const float duration = static_cast<float>(m_metadata.getMaxStopTimeOffset());
+  const float duration =
+      static_cast<float>(m_metadata_set.getMaxStopTimeOffset());
   m_simple_writer = new shiguredo::mp4::writer::SimpleWriter(
       m_ofs, {.mvhd_timescale = 1000, .duration = duration});
-  initialize(m_config, m_metadata, m_simple_writer, duration);
+  initialize(m_config, m_metadata_set, m_simple_writer, duration);
 }
 
 SimpleMP4Muxer::~SimpleMP4Muxer() {

--- a/src/muxer/simple_mp4_muxer.hpp
+++ b/src/muxer/simple_mp4_muxer.hpp
@@ -14,7 +14,7 @@ namespace hisui::muxer {
 
 class SimpleMP4Muxer : public MP4Muxer {
  public:
-  SimpleMP4Muxer(const hisui::Config&, const hisui::Metadata&);
+  SimpleMP4Muxer(const hisui::Config&, const hisui::MetadataSet&);
   ~SimpleMP4Muxer();
 
   void setUp() override;
@@ -25,7 +25,7 @@ class SimpleMP4Muxer : public MP4Muxer {
   shiguredo::mp4::writer::SimpleWriter* m_simple_writer;
 
   hisui::Config m_config;
-  hisui::Metadata m_metadata;
+  hisui::MetadataSet m_metadata_set;
 };
 
 }  // namespace hisui::muxer

--- a/src/muxer/video_producer.cpp
+++ b/src/muxer/video_producer.cpp
@@ -1,6 +1,7 @@
 #include "muxer/video_producer.hpp"
 
 #include <bits/exception.h>
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include <cmath>
@@ -13,7 +14,7 @@
 #include <progresscpp/ProgressBar.hpp>
 
 #include "constants.hpp"
-#include "util/interval.hpp"
+#include "frame.hpp"
 #include "video/composer.hpp"
 #include "video/encoder.hpp"
 #include "video/sequencer.hpp"

--- a/src/muxer/video_producer.hpp
+++ b/src/muxer/video_producer.hpp
@@ -8,7 +8,11 @@
 #include <boost/cstdint.hpp>
 #include <boost/rational.hpp>
 
-#include "frame.hpp"
+namespace hisui {
+
+struct Frame;
+
+}
 
 namespace hisui::video {
 
@@ -29,7 +33,7 @@ class VideoProducer {
  public:
   explicit VideoProducer(const VideoProducerParameters&);
   virtual ~VideoProducer();
-  void produce();
+  virtual void produce();
   void bufferPop();
   std::optional<hisui::Frame> bufferFront();
   bool isFinished();

--- a/src/video/basic_sequencer.hpp
+++ b/src/video/basic_sequencer.hpp
@@ -20,7 +20,8 @@ class BasicSequencer : public Sequencer {
   explicit BasicSequencer(const std::vector<hisui::Archive>&);
   ~BasicSequencer();
 
-  void getYUVs(std::vector<const YUVImage*>*, const std::uint64_t);
+  SequencerGetYUVsResult getYUVs(std::vector<const YUVImage*>*,
+                                 const std::uint64_t);
 
  private:
   const YUVImage* m_black_yuv_image;

--- a/src/video/buffer_vpx_encoder.hpp
+++ b/src/video/buffer_vpx_encoder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vpx/vpx_codec.h>
+#include <vpx/vpx_encoder.h>
 #include <vpx/vpx_image.h>
 
 #include <cstdint>
@@ -29,20 +30,25 @@ class BufferVPXEncoder : public Encoder {
       std::queue<hisui::Frame>*,
       const VPXEncoderConfig&,
       const std::uint64_t timescale = hisui::Constants::NANO_SECOND);
-  void outputImage(const std::vector<unsigned char>&);
-  void flush();
   ~BufferVPXEncoder();
 
+  void outputImage(const std::vector<unsigned char>&);
+  void flush();
   std::uint32_t getFourcc() const;
+  void setResolutionAndBitrate(const std::uint32_t,
+                               const std::uint32_t,
+                               const std::uint32_t);
 
  private:
   std::queue<hisui::Frame>* m_buffer;
   std::uint32_t m_width;
   std::uint32_t m_height;
+  std::uint32_t m_bitrate;
   boost::rational<std::uint64_t> m_fps;
   std::uint32_t m_fourcc;
   int m_frame = 0;
   ::vpx_codec_ctx_t m_codec;
+  ::vpx_codec_enc_cfg_t m_cfg;
   ::vpx_image_t m_raw_vpx_image;
   std::uint64_t m_sum_of_bits = 0;
   const std::uint64_t m_timescale;

--- a/src/video/encoder.hpp
+++ b/src/video/encoder.hpp
@@ -10,6 +10,9 @@ class Encoder {
   virtual ~Encoder() = default;
   virtual void outputImage(const std::vector<unsigned char>&) = 0;
   virtual void flush() = 0;
+  virtual void setResolutionAndBitrate(const std::uint32_t,
+                                       const std::uint32_t,
+                                       const std::uint32_t) {}
 
   virtual std::uint32_t getFourcc() const = 0;
 };

--- a/src/video/grid_composer.cpp
+++ b/src/video/grid_composer.cpp
@@ -1,5 +1,7 @@
 #include "video/grid_composer.hpp"
 
+#include <libyuv/scale.h>
+
 #include <algorithm>
 
 #include "video/preserve_aspect_ratio_scaler.hpp"

--- a/src/video/multi_channel_sequencer.hpp
+++ b/src/video/multi_channel_sequencer.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "video/sequencer.hpp"
+
+namespace hisui {
+
+class Archive;
+
+}
+
+namespace hisui::video {
+
+class YUVImage;
+
+class MultiChannelSequencer : public Sequencer {
+ public:
+  explicit MultiChannelSequencer(const std::vector<hisui::Archive>&,
+                                 const std::vector<hisui::Archive>&);
+  ~MultiChannelSequencer();
+
+  SequencerGetYUVsResult getYUVs(std::vector<const YUVImage*>*,
+                                 const std::uint64_t);
+
+ private:
+  const YUVImage* m_black_yuv_image;
+  std::vector<
+      std::pair<std::string, std::shared_ptr<std::vector<SourceAndInterval>>>>
+      m_preferred_sequence;
+};
+
+}  // namespace hisui::video

--- a/src/video/openh264_decoder.cpp
+++ b/src/video/openh264_decoder.cpp
@@ -1,9 +1,11 @@
 #include "video/openh264_decoder.hpp"
 
+#include <bits/exception.h>
 #include <codec/api/svc/codec_api.h>
 #include <codec/api/svc/codec_app_def.h>
 #include <codec/api/svc/codec_def.h>
 #include <fmt/core.h>
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include <limits>

--- a/src/video/openh264_decoder.hpp
+++ b/src/video/openh264_decoder.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <codec/api/svc/codec_def.h>
-
 #include <cstdint>
 #include <memory>
 

--- a/src/video/parallel_grid_composer.cpp
+++ b/src/video/parallel_grid_composer.cpp
@@ -1,6 +1,7 @@
 #include "video/parallel_grid_composer.hpp"
 
 #include <cxxabi.h>
+#include <libyuv/scale.h>
 
 #include <algorithm>
 #include <future>

--- a/src/video/preserve_aspect_ratio_scaler.cpp
+++ b/src/video/preserve_aspect_ratio_scaler.cpp
@@ -1,6 +1,7 @@
 #include "video/preserve_aspect_ratio_scaler.hpp"
 
 #include <bits/exception.h>
+#include <spdlog/fmt/bundled/format.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
@@ -9,6 +10,7 @@
 #include <stdexcept>
 
 #include <boost/cstdint.hpp>
+#include <boost/exception/exception.hpp>
 #include <boost/rational.hpp>
 
 #include "video/yuv.hpp"

--- a/src/video/sequencer.cpp
+++ b/src/video/sequencer.cpp
@@ -1,5 +1,23 @@
 #include "video/sequencer.hpp"
 
+#include <bits/exception.h>
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <iterator>
+#include <set>
+
+#include "constants.hpp"
+#include "metadata.hpp"
+#include "util/interval.hpp"
+#include "video/image_source.hpp"
+#include "video/source.hpp"
+#include "video/webm_source.hpp"
+
 namespace hisui::video {
 
 std::uint32_t Sequencer::getMaxWidth() const {
@@ -14,4 +32,59 @@ std::size_t Sequencer::getSize() const {
   return m_size;
 }
 
+MakeSequenceResult make_sequence(const std::vector<hisui::Archive>& archives) {
+  MakeSequenceResult result;
+  auto& sequence = result.sequence;
+  auto& max_width = result.max_width;
+  auto& max_height = result.max_height;
+
+  const std::set<std::string> image_extensions({".png", ".jpg", ".jpeg"});
+
+  for (const auto& archive : archives) {
+    Source* source;
+    const auto& path = archive.getPath();
+    const auto extension = path.extension();
+    if (extension == ".webm") {
+      source = new WebMSource(path.string());
+    } else if (image_extensions.contains(extension)) {
+      source = new ImageSource(path.string());
+    } else {
+      spdlog::info("unsupported video source: {}", path.string());
+      continue;
+    }
+    const auto width = source->getWidth();
+    const auto height = source->getHeight();
+    if (width > max_width) {
+      max_width = width;
+    }
+    if (height > max_height) {
+      max_height = height;
+    }
+    const auto connection_id = archive.getConnectionID();
+    const auto it = std::find_if(
+        std::begin(sequence), std::end(sequence),
+        [connection_id](
+            const std::pair<std::string,
+                            std::shared_ptr<std::vector<SourceAndInterval>>>&
+                elem) { return elem.first == connection_id; });
+    std::shared_ptr<std::vector<SourceAndInterval>> v;
+    if (it == std::end(sequence)) {
+      v = std::make_shared<std::vector<SourceAndInterval>>();
+      sequence.emplace_back(connection_id, v);
+    } else {
+      v = (*it).second;
+    }
+    v->push_back({std::unique_ptr<Source>(source),
+                  hisui::util::Interval(static_cast<std::uint64_t>(std::floor(
+                                            archive.getStartTimeOffset() *
+                                            hisui::Constants::NANO_SECOND)),
+                                        static_cast<std::uint64_t>(std::ceil(
+                                            archive.getStopTimeOffset() *
+                                            hisui::Constants::NANO_SECOND)))});
+  }
+
+  return result;
+}
+
 }  // namespace hisui::video
+

--- a/src/video/sequencer.hpp
+++ b/src/video/sequencer.hpp
@@ -2,15 +2,16 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-namespace hisui::util {
+#include "util/interval.hpp"
 
-class Interval;
+namespace hisui {
+
+class Archive;
 
 }
 
@@ -22,11 +23,16 @@ class YUVImage;
 using SourceAndInterval =
     std::pair<std::unique_ptr<Source>, hisui::util::Interval>;
 
+struct SequencerGetYUVsResult {
+  const bool is_preferred_stream = false;
+};
+
 class Sequencer {
  public:
   virtual ~Sequencer() = default;
 
-  virtual void getYUVs(std::vector<const YUVImage*>*, const std::uint64_t) = 0;
+  virtual SequencerGetYUVsResult getYUVs(std::vector<const YUVImage*>*,
+                                         const std::uint64_t) = 0;
 
   std::uint32_t getMaxWidth() const;
   std::uint32_t getMaxHeight() const;
@@ -40,5 +46,15 @@ class Sequencer {
   std::uint32_t m_max_height;
   std::size_t m_size;
 };
+
+struct MakeSequenceResult {
+  std::vector<
+      std::pair<std::string, std::shared_ptr<std::vector<SourceAndInterval>>>>
+      sequence{};
+  std::uint32_t max_width = 0;
+  std::uint32_t max_height = 0;
+};
+
+MakeSequenceResult make_sequence(const std::vector<hisui::Archive>&);
 
 }  // namespace hisui::video

--- a/src/video/simple_scaler.cpp
+++ b/src/video/simple_scaler.cpp
@@ -1,6 +1,7 @@
 #include "video/simple_scaler.hpp"
 
 #include <fmt/core.h>
+#include <libyuv/scale.h>
 
 #include <array>
 #include <stdexcept>

--- a/src/video/vpx.cpp
+++ b/src/video/vpx.cpp
@@ -2,6 +2,7 @@
 
 #include <bits/exception.h>
 #include <fmt/core.h>
+#include <spdlog/fmt/bundled/format.h>
 #include <spdlog/spdlog.h>
 #include <vpx/vp8cx.h>
 #include <vpx/vp8dx.h>
@@ -138,14 +139,14 @@ void update_vpx_image_by_yuv_data(::vpx_image_t* img,
 }
 
 void create_vpx_codec_ctx_t_for_encoding(::vpx_codec_ctx_t* codec,
+                                         ::vpx_codec_enc_cfg_t* cfg,
                                          const VPXEncoderConfig& config) {
   const auto dx_algo = get_vpx_encode_codec_iface_by_fourcc(config.fourcc);
   if (!dx_algo) {
     throw std::runtime_error("get_vpx_encode_codec_iface_by_fourcc() failed");
   }
 
-  ::vpx_codec_enc_cfg_t cfg;
-  const auto ret = ::vpx_codec_enc_config_default(dx_algo, &cfg, 0);
+  const auto ret = ::vpx_codec_enc_config_default(dx_algo, cfg, 0);
   if (ret) {
     throw std::runtime_error(
         fmt::format("vpx_codec_enc_config_default() failed: error_code={}",
@@ -157,18 +158,18 @@ void create_vpx_codec_ctx_t_for_encoding(::vpx_codec_ctx_t* codec,
   spdlog::debug("target_bitrate={} cq_level={} min_q={}, max_q={}",
                 config.bitrate, config.cq_level, config.min_q, config.max_q);
 
-  cfg.g_w = config.width;
-  cfg.g_h = config.height;
-  cfg.g_timebase.num = static_cast<int>(config.fps.denominator());
-  cfg.g_timebase.den = static_cast<int>(config.fps.numerator());
-  cfg.rc_target_bitrate = config.bitrate;
-  cfg.rc_end_usage = VPX_CQ;
-  cfg.rc_min_quantizer = config.min_q;
-  cfg.rc_max_quantizer = config.max_q;
+  cfg->g_w = config.width;
+  cfg->g_h = config.height;
+  cfg->g_timebase.num = static_cast<int>(config.fps.denominator());
+  cfg->g_timebase.den = static_cast<int>(config.fps.numerator());
+  cfg->rc_target_bitrate = config.bitrate;
+  cfg->rc_end_usage = VPX_CQ;
+  cfg->rc_min_quantizer = config.min_q;
+  cfg->rc_max_quantizer = config.max_q;
 
-  cfg.g_threads = config.threads;
+  cfg->g_threads = config.threads;
 
-  if (::vpx_codec_enc_init(codec, dx_algo, &cfg, 0)) {
+  if (::vpx_codec_enc_init(codec, dx_algo, cfg, 0)) {
     throw std::runtime_error("vpx_codec_enc_init() failed");
   }
 

--- a/src/video/vpx.hpp
+++ b/src/video/vpx.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vpx/vpx_codec.h>
+#include <vpx/vpx_encoder.h>
 #include <vpx/vpx_image.h>
 
 #include <cstdint>
@@ -53,6 +54,7 @@ void update_vpx_image_by_yuv_data(::vpx_image_t*,
                                   const std::vector<std::uint8_t>&);
 
 void create_vpx_codec_ctx_t_for_encoding(::vpx_codec_ctx_t*,
+                                         ::vpx_codec_enc_cfg_t*,
                                          const VPXEncoderConfig&);
 
 void create_vpx_codec_ctx_t_for_decoding(::vpx_codec_ctx_t*,

--- a/src/video/webm_source.cpp
+++ b/src/video/webm_source.cpp
@@ -5,7 +5,6 @@
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
-#include <cstdio>
 #include <stdexcept>
 
 #include "constants.hpp"

--- a/src/video/webm_source.hpp
+++ b/src/video/webm_source.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
 
 #include "video/source.hpp"

--- a/src/webm/input/audio_context.cpp
+++ b/src/webm/input/audio_context.cpp
@@ -6,7 +6,10 @@
 #include <spdlog/spdlog.h>
 
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
+#include <stdexcept>
+
 #include "webm/input/context.hpp"
 
 namespace hisui::webm::input {

--- a/src/webm/input/audio_context.hpp
+++ b/src/webm/input/audio_context.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
 
 #include "webm/input/context.hpp"

--- a/src/webm/input/video_context.cpp
+++ b/src/webm/input/video_context.cpp
@@ -5,7 +5,9 @@
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
+#include <cstdio>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 
 #include "constants.hpp"

--- a/src/webm/input/video_context.hpp
+++ b/src/webm/input/video_context.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
 
 #include "webm/input/context.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(audio)
+add_subdirectory(metadata)
 add_subdirectory(util)
 add_subdirectory(video)

--- a/test/integration/metadata/case1.json
+++ b/test/integration/metadata/case1.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case1",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/integration/metadata/case2.json
+++ b/test/integration/metadata/case2.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case2",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/integration/metadata/case3.json
+++ b/test/integration/metadata/case3.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case3",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/integration/metadata/case4.json
+++ b/test/integration/metadata/case4.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case4",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/integration/metadata/case5.json
+++ b/test/integration/metadata/case5.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case5",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/integration/metadata/case6.json
+++ b/test/integration/metadata/case6.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case6",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/integration/metadata/case7.json
+++ b/test/integration/metadata/case7.json
@@ -1,4 +1,6 @@
 {
+  "recording_id": "case7",
+  "created_at": 1617259968,
   "archives": [
     {
       "connection_id": "1",

--- a/test/metadata/CMakeLists.txt
+++ b/test/metadata/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+add_compile_options(
+    -Wall
+    -Wextra
+    -Wshadow
+    -Wnon-virtual-dtor
+    -Wunused
+    -Wold-style-cast
+    -Wcast-align
+    -Woverloaded-virtual
+    -Wconversion
+    -Wsign-conversion
+    -Wmisleading-indentation
+    -pedantic)
+
+add_executable(metadata_test
+    main.cpp
+    time_offset.cpp
+    ../../src/metadata.cpp
+    )
+
+set_target_properties(metadata_test PROPERTIES CXX_STANDARD 20 C_STANDARD 11)
+
+target_include_directories(metadata_test
+    PRIVATE
+    ../../src
+    ${boost_algorithm_SOURCE_DIR}/include
+    ${boost_assert_SOURCE_DIR}/include
+    ${boost_bind_SOURCE_DIR}/include
+    ${boost_config_SOURCE_DIR}/include
+    ${boost_container_hash_SOURCE_DIR}/include
+    ${boost_core_SOURCE_DIR}/include
+    ${boost_detail_SOURCE_DIR}/include
+    ${boost_exception_SOURCE_DIR}/include
+    ${boost_function_SOURCE_DIR}/include
+    ${boost_integer_SOURCE_DIR}/include
+    ${boost_io_SOURCE_DIR}/include
+    ${boost_iterator_SOURCE_DIR}/include
+    ${boost_json_SOURCE_DIR}/include
+    ${boost_move_SOURCE_DIR}/include
+    ${boost_mpl_SOURCE_DIR}/include
+    ${boost_numeric_conversion_SOURCE_DIR}/include
+    ${boost_preprocessor_SOURCE_DIR}/include
+    ${boost_range_SOURCE_DIR}/include
+    ${boost_smart_ptr_SOURCE_DIR}/include
+    ${boost_static_assert_SOURCE_DIR}/include
+    ${boost_test_SOURCE_DIR}/include
+    ${boost_throw_exception_SOURCE_DIR}/include
+    ${boost_type_index_SOURCE_DIR}/include
+    ${boost_type_traits_SOURCE_DIR}/include
+    ${boost_utility_SOURCE_DIR}/include
+    ${fmt_SOURCE_DIR}/include
+    ${spdlog_SOURCE_DIR}/include
+    )
+
+target_link_libraries(metadata_test
+    PRIVATE
+    Boost::json
+    fmt
+    spdlog
+    )
+
+
+add_test(NAME metadata COMMAND metadata_test)
+set_tests_properties(metadata PROPERTIES LABELS hisui)

--- a/test/metadata/main.cpp
+++ b/test/metadata/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE "hisui::metadata test"
+#include <boost/test/included/unit_test.hpp>

--- a/test/metadata/time_offset.cpp
+++ b/test/metadata/time_offset.cpp
@@ -1,0 +1,53 @@
+#include <boost/test/unit_test.hpp>
+
+#include <boost/json.hpp>
+
+#include "metadata.hpp"
+
+BOOST_AUTO_TEST_SUITE(time_offset)
+
+BOOST_AUTO_TEST_CASE(archive_adjust_time_offsets) {
+  hisui::Archive archive("dummy", "connection_id", 0, 10);
+  archive.adjustTimeOffsets(1.5);
+  BOOST_REQUIRE_CLOSE(1.5, archive.getStartTimeOffset(), 0.00001);
+  BOOST_REQUIRE_CLOSE(11.5, archive.getStopTimeOffset(), 0.00001);
+  archive.adjustTimeOffsets(-0.5);
+  BOOST_REQUIRE_CLOSE(1.0, archive.getStartTimeOffset(), 0.00001);
+  BOOST_REQUIRE_CLOSE(11.0, archive.getStopTimeOffset(), 0.00001);
+}
+
+BOOST_AUTO_TEST_CASE(metadata_adjust_time_offsets) {
+  hisui::Metadata metadata({
+      {"dummy", "connection_id", 0, 10},
+      {"dummy", "connection_id", 10, 30},
+      {"dummy", "connection_id", 15, 20},
+  });
+  BOOST_REQUIRE_EQUAL(0, metadata.getMinStartTimeOffset());
+  BOOST_REQUIRE_EQUAL(30, metadata.getMaxStopTimeOffset());
+  metadata.adjustTimeOffsets(1.5);
+  BOOST_REQUIRE_CLOSE(1.5, metadata.getMinStartTimeOffset(), 0.00001);
+  BOOST_REQUIRE_CLOSE(31.5, metadata.getMaxStopTimeOffset(), 0.00001);
+  {
+    auto archives = metadata.getArchives();
+    BOOST_REQUIRE_CLOSE(1.5, archives[0].getStartTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(11.5, archives[0].getStopTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(11.5, archives[1].getStartTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(31.5, archives[1].getStopTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(16.5, archives[2].getStartTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(21.5, archives[2].getStopTimeOffset(), 0.00001);
+  }
+  metadata.adjustTimeOffsets(-1.0);
+  BOOST_REQUIRE_CLOSE(0.5, metadata.getMinStartTimeOffset(), 0.00001);
+  BOOST_REQUIRE_CLOSE(30.5, metadata.getMaxStopTimeOffset(), 0.00001);
+  {
+    auto archives = metadata.getArchives();
+    BOOST_REQUIRE_CLOSE(0.5, archives[0].getStartTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(10.5, archives[0].getStopTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(10.5, archives[1].getStartTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(30.5, archives[1].getStopTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(15.5, archives[2].getStartTimeOffset(), 0.00001);
+    BOOST_REQUIRE_CLOSE(20.5, archives[2].getStopTimeOffset(), 0.00001);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`--screen-capture-report` で指定された report- ファイルのチャンネルを, `-f,--in-metadata-file` で指定されたものより優先して表示するように合成する機能を追加しました.

2 つのチャンネルは, report- ファイル中の `created_at` key を利用して表示される時間を補正します.

前述の時間補正をしたうえで, `--screen-capture-report` で指定されたチャンネルの archive の `start_time_offset` と `stop_time_offset` の間は このチャンネルの動画のみを表示するように合成します.

`--screen-capture-report` で指定されたものの中で時間が重なった archive がある場合は そのうちの 1 つのみを利用します.


## 追加したコマンドラインオプション

width/height/bit-rate, 画面共有の音声を mix するかを指定できます.

```
Experimental Options:
  --screen-capture-report     Screen Capture Metadata filename
  --screen-capture-connection-id
                              Screen capture connection id
  --screen-capture-width      Width for screen-capture (NON NAGATIVE multiple of 4). default: 960
  --screen-capture-height     Height for screen-capture (NON NAGATIVE multiple of 4). default: 640
  --screen-capture-bit-rate   Bit rate for screen-capture (kbps). default: 1000
  --mix-screen-capture-audio  Mix screen-capture audio. default: false)
```

## 実行イメージ

```
./release/hisui -f .../report-2A0EVXFRVS7BSCEV4EQJ3MW4VC.json --screen-capture-report .../report-GACVGHQB953FX8GFG98AY3XGXR.json 
```
