### PR TITLE
Add hisui::layout::overlap_trim_intervals()

### DIFF
--- a/src/layout/overlap.hpp
+++ b/src/layout/overlap.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <list>
 #include <utility>
 #include <vector>
 
@@ -29,4 +30,20 @@ std::ostream& operator<<(
 
 MaxNumberOfOverlapAndMaxEndTimeAndTrimIntervals overlap(
     const OverlapParameters&);
+
+struct TrimIntervals {
+  std::vector<std::pair<std::uint64_t, std::uint64_t>> trim_intervals;
+};
+
+bool operator==(TrimIntervals const& left, TrimIntervals const& right);
+
+std::ostream& operator<<(std::ostream& os, const TrimIntervals&);
+
+struct OverlapTrimIntervalsParameters {
+  const std::list<std::vector<std::pair<std::uint64_t, std::uint64_t>>>&
+      list_of_trim_intervals;
+};
+
+TrimIntervals overlap_trim_intervals(const OverlapTrimIntervalsParameters&);
+
 }  // namespace hisui::layout

--- a/test/layout/overlap_test.cpp
+++ b/test/layout/overlap_test.cpp
@@ -236,4 +236,104 @@ BOOST_AUTO_TEST_CASE(overlap) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(overlap_trim_intervals) {
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {}}));
+  }
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{0, 100}, {200, 300}},
+    };
+    BOOST_REQUIRE_EQUAL(
+        expected, hisui::layout::overlap_trim_intervals(
+                      {.list_of_trim_intervals = {{{0, 100}, {200, 300}}}}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{0, 100}, {200, 300}},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{0, 100}, {200, 300}},
+                                           {{0, 200}, {200, 400}},
+                                       }}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{0, 100}},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{0, 100}, {200, 300}},
+                                           {{0, 200}},
+                                           {{0, 400}},
+                                       }}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{0, 100}, {200, 300}},
+                                           {{0, 200}},
+                                           {},
+                                           {{0, 400}},
+                                       }}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{0, 100}, {250, 300}},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{0, 100}, {200, 300}},
+                                           {{0, 200}, {250, 300}},
+                                           {{0, 400}},
+                                       }}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{200, 300}},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{0, 100}, {200, 350}},
+                                           {{200, 300}},
+                                       }}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{200, 300}},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{200, 300}},
+                                           {{0, 100}, {200, 350}},
+                                       }}));
+  }
+
+  {
+    auto expected = hisui::layout::TrimIntervals{
+        .trim_intervals = {{250, 300}},
+    };
+    BOOST_REQUIRE_EQUAL(expected, hisui::layout::overlap_trim_intervals(
+                                      {.list_of_trim_intervals = {
+                                           {{0, 100}, {200, 350}},
+                                           {{200, 300}},
+                                           {{250, 400}},
+                                       }}));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
region 間で trim 可能な interval の重なっている部分を算出するための関数
