### PR TITLE
--openh264-profile と --openh264-level オプションの追加

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,6 @@
 #include "config.hpp"
 
+#include <codec/api/wels/codec_app_def.h>
 #include <libyuv/scale.h>
 #include <spdlog/common.h>
 
@@ -275,6 +276,29 @@ void set_cli_options(CLI::App* app, Config* config) {
   app->add_option("--openh264-max-qp", config->openh264_max_qp,
                   "OpenH264 maximum QP encoder supports. default: 51")
       ->check(CLI::Range(0, 51))
+      ->group(OPTIONS_FOR_TUNING);
+
+  std::vector<std::pair<std::string, ::EProfileIdc>> openh264_profile_assoc{
+      {"baseline", ::PRO_BASELINE},
+      {"main", ::PRO_MAIN},
+      {"high", ::PRO_HIGH},
+  };
+  app->add_option("--openh264-profile", config->openh264_profile,
+                  "OpenH264 Profile (baseline/main/high). default: baseline")
+      ->transform(
+          CLI::CheckedTransformer(openh264_profile_assoc, CLI::ignore_case))
+      ->group(OPTIONS_FOR_TUNING);
+
+  std::vector<std::pair<std::string, ::ELevelIdc>> openh264_level_assoc{
+      {"3.0", ::LEVEL_3_0}, {"3.1", ::LEVEL_3_1}, {"3.2", ::LEVEL_3_2},
+      {"4.0", ::LEVEL_4_0}, {"4.1", ::LEVEL_4_1}, {"4.2", ::LEVEL_4_2},
+      {"5.0", ::LEVEL_5_0}, {"5.1", ::LEVEL_5_1}, {"5.2", ::LEVEL_5_2},
+  };
+  app->add_option(
+         "--openh264-level", config->openh264_level,
+         "OpenH264 Level (3.0/3.1/3.2/4.0/4.1/4.2/5.0/5.1/5.2). default: 3.1")
+      ->transform(
+          CLI::CheckedTransformer(openh264_level_assoc, CLI::ignore_case))
       ->group(OPTIONS_FOR_TUNING);
 
   std::vector<std::pair<std::string, spdlog::level::level_enum>>

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <codec/api/wels/codec_app_def.h>
 #include <libyuv/scale.h>
 #include <spdlog/common.h>
 
@@ -119,6 +120,8 @@ class Config {
   std::uint16_t openh264_threads = 1;
   std::int32_t openh264_min_qp = 0;
   std::int32_t openh264_max_qp = 51;
+  ::EProfileIdc openh264_profile = ::PRO_BASELINE;
+  ::ELevelIdc openh264_level = ::LEVEL_3_1;
 
   libyuv::FilterMode libyuv_filter_mode = libyuv::kFilterBox;
 

--- a/src/hisui.cpp
+++ b/src/hisui.cpp
@@ -34,8 +34,6 @@ int main(int argc, char** argv) {
 
     CLI11_PARSE(app, argc, argv);
 
-    config.validate();
-
     if (config.version) {
       std::cout << "Recording Composition Tool Hisui "
                 << hisui::version::get_hisui_version() << std::endl;
@@ -68,6 +66,8 @@ int main(int argc, char** argv) {
   if (!std::empty(config.layout)) {
     return hisui::layout::compose(config);
   }
+
+  config.validate();
 
   if (std::empty(config.in_metadata_filename)) {
     spdlog::error("-f,--in-metadata-file is required");

--- a/src/layout/compose.cpp
+++ b/src/layout/compose.cpp
@@ -24,6 +24,8 @@ int compose(const hisui::Config& t_config) {
   auto metadata = hisui::layout::parse_metadata(config);
   metadata.copyToConfig(&config);
 
+  config.validate();
+
   std::shared_ptr<hisui::muxer::Muxer> muxer;
   std::shared_ptr<muxer::VideoProducer> video_producer;
   try {

--- a/src/video/buffer_openh264_encoder.cpp
+++ b/src/video/buffer_openh264_encoder.cpp
@@ -50,8 +50,8 @@ BufferOpenH264Encoder::BufferOpenH264Encoder(
   param.iUsageType = CAMERA_VIDEO_REAL_TIME;  // TODO(haruyama): config にする?
   param.iRCMode = RC_QUALITY_MODE;
   for (auto i = 0; i < MAX_SPATIAL_LAYER_NUM; ++i) {
-    param.sSpatialLayers[i].uiLevelIdc = LEVEL_3_1;
-    param.sSpatialLayers[i].uiProfileIdc = PRO_BASELINE;
+    param.sSpatialLayers[i].uiLevelIdc = config.level;
+    param.sSpatialLayers[i].uiProfileIdc = config.profile;
   }
   param.fMaxFrameRate = static_cast<float>(m_fps.numerator()) /
                         static_cast<float>(m_fps.denominator());

--- a/src/video/openh264.cpp
+++ b/src/video/openh264.cpp
@@ -53,6 +53,8 @@ OpenH264EncoderConfig::OpenH264EncoderConfig(const std::uint32_t t_width,
       bitrate(config.out_video_bit_rate),
       threads(config.openh264_threads),
       min_qp(config.openh264_min_qp),
-      max_qp(config.openh264_max_qp) {}
+      max_qp(config.openh264_max_qp),
+      profile(config.openh264_profile),
+      level(config.openh264_level) {}
 
 }  // namespace hisui::video

--- a/src/video/openh264.hpp
+++ b/src/video/openh264.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <codec/api/wels/codec_app_def.h>
 #include <codec/api/wels/codec_def.h>
 
 #include <cstdint>
@@ -30,6 +31,8 @@ class OpenH264EncoderConfig {
   const std::uint16_t threads;
   const std::int32_t min_qp;
   const std::int32_t max_qp;
+  const ::EProfileIdc profile = ::PRO_BASELINE;
+  const ::ELevelIdc level = ::LEVEL_3_1;
 };
 
 }  // namespace hisui::video

--- a/test/video/CMakeLists.txt
+++ b/test/video/CMakeLists.txt
@@ -60,7 +60,7 @@ target_include_directories(video_test
     ${fmt_SOURCE_DIR}/include
     ${spdlog_SOURCE_DIR}/include
     ../../src
-    ../../src/third_party/openh264/codec/api/wels
+    ../../third_party/openh264
     ../../third_party/libvpx
     ../../third_party/libvpx/third_party/libwebm
     ../../third_party/libvpx/third_party/libyuv/include


### PR DESCRIPTION
--openh264-profile は baseline/main/high を
--openh264-level は 3.0/3.1/3.2/4.0/4.1/4.2/5.0/5.1/5.2 が指定可能です